### PR TITLE
Uses `google.golang.org/api/compute/v1` package

### DIFF
--- a/app/gcp/instancemanager.go
+++ b/app/gcp/instancemanager.go
@@ -18,15 +18,13 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 
 	apiv1 "cloud-android-orchestration/api/v1"
 	"cloud-android-orchestration/app"
 
-	compute "cloud.google.com/go/compute/apiv1"
-	"github.com/google/uuid"
+	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/option"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
-	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -38,21 +36,10 @@ const (
 
 // GCP implementation of the instance manager.
 type InstanceManager struct {
-	config      *app.IMConfig
-	client      *compute.InstancesClient
-	uuidFactory func() string
-}
-
-func NewInstanceManager(config *app.IMConfig, ctx context.Context, opts ...option.ClientOption) (*InstanceManager, error) {
-	client, err := compute.NewInstancesRESTClient(ctx, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return &InstanceManager{
-		config:      config,
-		client:      client,
-		uuidFactory: func() string { return uuid.New().String() },
-	}, nil
+	Config                app.IMConfig
+	Client                *http.Client
+	InstanceNameGenerator NameGenerator
+	ServiceURL            string // If empty, default will be used
 }
 
 func (m *InstanceManager) GetHostAddr(zone string, host string) (string, error) {
@@ -68,71 +55,80 @@ func (m *InstanceManager) GetHostAddr(zone string, host string) (string, error) 
 	if ilen > 1 {
 		log.Printf("host instance %s in zone %s has %d network interfaces", host, zone, ilen)
 	}
-	return *instance.NetworkInterfaces[0].NetworkIP, nil
+	return instance.NetworkInterfaces[0].NetworkIP, nil
 }
 
 func (m *InstanceManager) CreateHost(zone string, req *apiv1.CreateHostRequest, user app.UserInfo) (*apiv1.Operation, error) {
 	if err := validateRequest(req); err != nil {
 		return nil, err
 	}
+	ctx := context.TODO()
+	service, err := compute.NewService(
+		ctx,
+		option.WithHTTPClient(m.Client),
+		option.WithEndpoint(m.ServiceURL),
+	)
+	if err != nil {
+		return nil, err
+	}
 	labels := map[string]string{
 		labelAcloudCreatedBy: user.Username(),
 		labelCreatedBy:       user.Username(),
 	}
-	ctx := context.TODO()
-	computeReq := &computepb.InsertInstanceRequest{
-		Project: m.config.GCP.ProjectID,
-		Zone:    zone,
-		InstanceResource: &computepb.Instance{
-			Name:           proto.String(namePrefix + m.uuidFactory()),
-			MachineType:    proto.String(req.CreateHostInstanceRequest.GCP.MachineType),
-			MinCpuPlatform: proto.String(req.CreateHostInstanceRequest.GCP.MinCPUPlatform),
-			Disks: []*computepb.AttachedDisk{
-				{
-					InitializeParams: &computepb.AttachedDiskInitializeParams{
-						DiskSizeGb:  proto.Int64(int64(req.CreateHostInstanceRequest.GCP.DiskSizeGB)),
-						SourceImage: proto.String(m.config.GCP.HostImage),
-					},
-					Boot: proto.Bool(true),
+	payload := &compute.Instance{
+		Name:           m.InstanceNameGenerator.NewName(),
+		MachineType:    req.CreateHostInstanceRequest.GCP.MachineType,
+		MinCpuPlatform: req.CreateHostInstanceRequest.GCP.MinCPUPlatform,
+		Disks: []*compute.AttachedDisk{
+			{
+				InitializeParams: &compute.AttachedDiskInitializeParams{
+					DiskSizeGb:  int64(req.CreateHostInstanceRequest.GCP.DiskSizeGB),
+					SourceImage: m.Config.GCP.HostImage,
 				},
+				Boot: true,
 			},
-			NetworkInterfaces: []*computepb.NetworkInterface{
-				{
-					Name: proto.String(buildDefaultNetworkName(m.config.GCP.ProjectID)),
-					AccessConfigs: []*computepb.AccessConfig{
-						{
-							Name: proto.String("External NAT"),
-							Type: proto.String(computepb.AccessConfig_ONE_TO_ONE_NAT.String()),
-						},
-					},
-				},
-			},
-			Labels: labels,
 		},
+		NetworkInterfaces: []*compute.NetworkInterface{
+			{
+				Name: buildDefaultNetworkName(m.Config.GCP.ProjectID),
+				AccessConfigs: []*compute.AccessConfig{
+					{
+						Name: "External NAT",
+						Type: "ONE_TO_ONE_NAT",
+					},
+				},
+			},
+		},
+		Labels: labels,
 	}
-	op, err := m.client.Insert(ctx, computeReq)
+	op, err := service.Instances.
+		Insert(m.Config.GCP.ProjectID, zone, payload).
+		Context(ctx).
+		Do()
 	if err != nil {
 		return nil, err
 	}
 	result := &apiv1.Operation{
-		Name: op.Name(),
-		Done: op.Done(),
+		Name: op.Name,
+		Done: op.Status == "DONE",
 	}
 	return result, nil
 }
 
-func (m *InstanceManager) Close() error {
-	return m.client.Close()
-}
-
-func (m *InstanceManager) getHostInstance(zone string, host string) (*computepb.Instance, error) {
+func (m *InstanceManager) getHostInstance(zone string, host string) (*compute.Instance, error) {
 	ctx := context.TODO()
-	req := &computepb.GetInstanceRequest{
-		Project:  m.config.GCP.ProjectID,
-		Zone:     zone,
-		Instance: host,
+	service, err := compute.NewService(
+		ctx,
+		option.WithHTTPClient(m.Client),
+		option.WithEndpoint(m.ServiceURL),
+	)
+	if err != nil {
+		return nil, err
 	}
-	return m.client.Get(ctx, req)
+	return service.Instances.
+		Get(m.Config.GCP.ProjectID, zone, host).
+		Context(ctx).
+		Do()
 }
 
 func validateRequest(r *apiv1.CreateHostRequest) error {
@@ -149,7 +145,16 @@ func buildDefaultNetworkName(projectID string) string {
 	return fmt.Sprintf("projects/%s/global/networks/default", projectID)
 }
 
-// Internal setter method used for testing only.
-func (m *InstanceManager) setUUIDFactory(newFactory func() string) {
-	m.uuidFactory = newFactory
+const hostInstanceNamePrefix = "cf-"
+
+type NameGenerator interface {
+	NewName() string
+}
+
+type InstanceNameGenerator struct {
+	UUIDFactory func() string
+}
+
+func (g *InstanceNameGenerator) NewName() string {
+	return namePrefix + g.UUIDFactory()
 }

--- a/app/gcp/instancemanager_test.go
+++ b/app/gcp/instancemanager_test.go
@@ -27,8 +27,6 @@ import (
 	"cloud-android-orchestration/app"
 
 	"github.com/sergi/go-diff/diffmatchpatch"
-	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/google"
 	"google.golang.org/api/compute/v1"
 )
 
@@ -38,8 +36,6 @@ var testConfig = app.IMConfig{
 		HostImage: "projects/test-project-releases/global/images/img-001",
 	},
 }
-
-var testClient, _ = google.DefaultClient(oauth2.NoContext)
 
 var testNameGenerator = &testConstantNameGenerator{name: "foo"}
 
@@ -56,7 +52,7 @@ func TestCreateHostInvalidRequests(t *testing.T) {
 	defer ts.Close()
 	im := InstanceManager{
 		Config:                testConfig,
-		Client:                testClient,
+		Client:                ts.Client(),
 		InstanceNameGenerator: testNameGenerator,
 		ServiceURL:            ts.URL,
 	}
@@ -105,7 +101,7 @@ func TestCreateHostRequestPath(t *testing.T) {
 	defer ts.Close()
 	im := InstanceManager{
 		Config:                testConfig,
-		Client:                testClient,
+		Client:                ts.Client(),
 		InstanceNameGenerator: testNameGenerator,
 		ServiceURL:            ts.URL,
 	}
@@ -140,7 +136,7 @@ func TestCreateHostRequestBody(t *testing.T) {
 	defer ts.Close()
 	im := InstanceManager{
 		Config:                testConfig,
-		Client:                testClient,
+		Client:                ts.Client(),
 		InstanceNameGenerator: testNameGenerator,
 		ServiceURL:            ts.URL,
 	}
@@ -205,7 +201,7 @@ func TestCreateHostSuccess(t *testing.T) {
 	defer ts.Close()
 	im := InstanceManager{
 		Config:                testConfig,
-		Client:                testClient,
+		Client:                ts.Client(),
 		InstanceNameGenerator: testNameGenerator,
 		ServiceURL:            ts.URL,
 	}
@@ -239,7 +235,7 @@ func TestGetHostAddrRequestPath(t *testing.T) {
 	defer ts.Close()
 	im := InstanceManager{
 		Config:                testConfig,
-		Client:                testClient,
+		Client:                ts.Client(),
 		InstanceNameGenerator: testNameGenerator,
 		ServiceURL:            ts.URL,
 	}
@@ -259,7 +255,7 @@ func TestGetHostAddrMissingNetworkInterface(t *testing.T) {
 	defer ts.Close()
 	im := InstanceManager{
 		Config:                testConfig,
-		Client:                testClient,
+		Client:                ts.Client(),
 		InstanceNameGenerator: testNameGenerator,
 		ServiceURL:            ts.URL,
 	}
@@ -287,7 +283,7 @@ func TestGetHostAddrSuccess(t *testing.T) {
 	defer ts.Close()
 	im := InstanceManager{
 		Config:                testConfig,
-		Client:                testClient,
+		Client:                ts.Client(),
 		InstanceNameGenerator: testNameGenerator,
 		ServiceURL:            ts.URL,
 	}

--- a/app/types.go
+++ b/app/types.go
@@ -50,8 +50,6 @@ type InstanceManager interface {
 	GetHostAddr(zone string, host string) (string, error)
 	// Creates a host instance.
 	CreateHost(zone string, req *apiv1.CreateHostRequest, user UserInfo) (*apiv1.Operation, error)
-	// Closes the connection with the underlying API
-	Close() error
 }
 
 type AuthHTTPHandler func(http.ResponseWriter, *http.Request, UserInfo) error

--- a/app/unix/instancemanager.go
+++ b/app/unix/instancemanager.go
@@ -32,5 +32,3 @@ func (d *InstanceManager) GetHostAddr(_ string, _ string) (string, error) {
 func (d *InstanceManager) CreateHost(_ string, _ *apiv1.CreateHostRequest, _ app.UserInfo) (*apiv1.Operation, error) {
 	return nil, app.NewInternalError(fmt.Sprintf("%T#CreateHost is not implemented", *d), nil)
 }
-
-func (d *InstanceManager) Close() error { return nil }


### PR DESCRIPTION
- Replaces the use of experimental package `google.golang.org/genproto/googleapis/cloud/compute/v1`.

- Updated deps with `go mod tidy`.