### PR TITLE
Uses `google.golang.org/api/compute/v1` package

### DIFF
--- a/app/gcp/instancemanager.go
+++ b/app/gcp/instancemanager.go
@@ -28,7 +28,6 @@ import (
 )
 
 const (
-	namePrefix           = "cf-"
 	labelPrefix          = "cf-"
 	labelAcloudCreatedBy = "created_by" // required for acloud backwards compatibility
 	labelCreatedBy       = labelPrefix + "created_by"
@@ -57,6 +56,8 @@ func (m *InstanceManager) GetHostAddr(zone string, host string) (string, error) 
 	}
 	return instance.NetworkInterfaces[0].NetworkIP, nil
 }
+
+const operationStatusDone = "DONE"
 
 func (m *InstanceManager) CreateHost(zone string, req *apiv1.CreateHostRequest, user app.UserInfo) (*apiv1.Operation, error) {
 	if err := validateRequest(req); err != nil {
@@ -110,7 +111,7 @@ func (m *InstanceManager) CreateHost(zone string, req *apiv1.CreateHostRequest, 
 	}
 	result := &apiv1.Operation{
 		Name: op.Name,
-		Done: op.Status == "DONE",
+		Done: op.Status == operationStatusDone,
 	}
 	return result, nil
 }
@@ -156,5 +157,5 @@ type InstanceNameGenerator struct {
 }
 
 func (g *InstanceNameGenerator) NewName() string {
-	return namePrefix + g.UUIDFactory()
+	return hostInstanceNamePrefix + g.UUIDFactory()
 }

--- a/app/gcp/instancemanager.go
+++ b/app/gcp/instancemanager.go
@@ -18,15 +18,13 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 
 	apiv1 "cloud-android-orchestration/api/v1"
 	"cloud-android-orchestration/app"
 
-	compute "cloud.google.com/go/compute/apiv1"
-	"github.com/google/uuid"
+	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/option"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
-	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -38,21 +36,10 @@ const (
 
 // GCP implementation of the instance manager.
 type InstanceManager struct {
-	config      *app.IMConfig
-	client      *compute.InstancesClient
-	uuidFactory func() string
-}
-
-func NewInstanceManager(config *app.IMConfig, ctx context.Context, opts ...option.ClientOption) (*InstanceManager, error) {
-	client, err := compute.NewInstancesRESTClient(ctx, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return &InstanceManager{
-		config:      config,
-		client:      client,
-		uuidFactory: func() string { return uuid.New().String() },
-	}, nil
+	Config                app.IMConfig
+	Client                *http.Client
+	InstanceNameGenerator NameGenerator
+	ServiceURL            string // If empty, default will be used
 }
 
 func (m *InstanceManager) GetHostAddr(zone string, host string) (string, error) {
@@ -68,71 +55,80 @@ func (m *InstanceManager) GetHostAddr(zone string, host string) (string, error) 
 	if ilen > 1 {
 		log.Printf("host instance %s in zone %s has %d network interfaces", host, zone, ilen)
 	}
-	return *instance.NetworkInterfaces[0].NetworkIP, nil
+	return instance.NetworkInterfaces[0].NetworkIP, nil
 }
 
 func (m *InstanceManager) CreateHost(zone string, req *apiv1.CreateHostRequest, user app.UserInfo) (*apiv1.Operation, error) {
 	if err := validateRequest(req); err != nil {
 		return nil, err
 	}
+	ctx := context.TODO()
+	service, err := compute.NewService(
+		ctx,
+		option.WithHTTPClient(m.Client),
+		option.WithEndpoint(m.ServiceURL),
+	)
+	if err != nil {
+		return nil, err
+	}
 	labels := map[string]string{
 		labelAcloudCreatedBy: user.Username(),
 		labelCreatedBy:       user.Username(),
 	}
-	ctx := context.TODO()
-	computeReq := &computepb.InsertInstanceRequest{
-		Project: m.config.GCP.ProjectID,
-		Zone:    zone,
-		InstanceResource: &computepb.Instance{
-			Name:           proto.String(namePrefix + m.uuidFactory()),
-			MachineType:    proto.String(req.CreateHostInstanceRequest.GCP.MachineType),
-			MinCpuPlatform: proto.String(req.CreateHostInstanceRequest.GCP.MinCPUPlatform),
-			Disks: []*computepb.AttachedDisk{
-				{
-					InitializeParams: &computepb.AttachedDiskInitializeParams{
-						DiskSizeGb:  proto.Int64(int64(req.CreateHostInstanceRequest.GCP.DiskSizeGB)),
-						SourceImage: proto.String(m.config.GCP.HostImage),
-					},
-					Boot: proto.Bool(true),
+	payload := &compute.Instance{
+		Name:           m.InstanceNameGenerator.NewName(),
+		MachineType:    req.CreateHostInstanceRequest.GCP.MachineType,
+		MinCpuPlatform: req.CreateHostInstanceRequest.GCP.MinCPUPlatform,
+		Disks: []*compute.AttachedDisk{
+			{
+				InitializeParams: &compute.AttachedDiskInitializeParams{
+					DiskSizeGb:  int64(req.CreateHostInstanceRequest.GCP.DiskSizeGB),
+					SourceImage: m.Config.GCP.HostImage,
 				},
+				Boot: true,
 			},
-			NetworkInterfaces: []*computepb.NetworkInterface{
-				{
-					Name: proto.String(buildDefaultNetworkName(m.config.GCP.ProjectID)),
-					AccessConfigs: []*computepb.AccessConfig{
-						{
-							Name: proto.String("External NAT"),
-							Type: proto.String(computepb.AccessConfig_ONE_TO_ONE_NAT.String()),
-						},
-					},
-				},
-			},
-			Labels: labels,
 		},
+		NetworkInterfaces: []*compute.NetworkInterface{
+			{
+				Name: buildDefaultNetworkName(m.Config.GCP.ProjectID),
+				AccessConfigs: []*compute.AccessConfig{
+					{
+						Name: "External NAT",
+						Type: "ONE_TO_ONE_NAT",
+					},
+				},
+			},
+		},
+		Labels: labels,
 	}
-	op, err := m.client.Insert(ctx, computeReq)
+	op, err := service.Instances.
+		Insert(m.Config.GCP.ProjectID, zone, payload).
+		Context(ctx).
+		Do()
 	if err != nil {
 		return nil, err
 	}
 	result := &apiv1.Operation{
-		Name: op.Name(),
-		Done: op.Done(),
+		Name: op.Name,
+		Done: op.Status == "DONE",
 	}
 	return result, nil
 }
 
-func (m *InstanceManager) Close() error {
-	return m.client.Close()
-}
-
-func (m *InstanceManager) getHostInstance(zone string, host string) (*computepb.Instance, error) {
+func (m *InstanceManager) getHostInstance(zone string, host string) (*compute.Instance, error) {
 	ctx := context.TODO()
-	req := &computepb.GetInstanceRequest{
-		Project:  m.config.GCP.ProjectID,
-		Zone:     zone,
-		Instance: host,
+	service, err := compute.NewService(
+		ctx,
+		option.WithHTTPClient(m.Client),
+		option.WithEndpoint(m.ServiceURL),
+	)
+	if err != nil {
+		return nil, err
 	}
-	return m.client.Get(ctx, req)
+	return service.Instances.
+		Get(m.Config.GCP.ProjectID, zone, host).
+		Context(ctx).
+		Do()
 }
 
 func validateRequest(r *apiv1.CreateHostRequest) error {
@@ -149,7 +145,16 @@ func buildDefaultNetworkName(projectID string) string {
 	return fmt.Sprintf("projects/%s/global/networks/default", projectID)
 }
 
-// Internal setter method used for testing only.
-func (m *InstanceManager) setUUIDFactory(newFactory func() string) {
-	m.uuidFactory = newFactory
+const hostInstanceNamePrefix = "cf-"
+
+type NameGenerator interface {
+	NewName() string
+}
+
+type InstanceNameGenerator struct {
+	UUIDFactory func() string
+}
+
+func (g *InstanceNameGenerator) NewName() string {
+	return namePrefix + g.UUIDFactory()
 }

--- a/app/gcp/instancemanager_test.go
+++ b/app/gcp/instancemanager_test.go
@@ -16,7 +16,6 @@ package gcp
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"io/ioutil"
@@ -28,17 +27,17 @@ import (
 	"cloud-android-orchestration/app"
 
 	"github.com/sergi/go-diff/diffmatchpatch"
-	"google.golang.org/api/option"
-	computepb "google.golang.org/genproto/googleapis/cloud/compute/v1"
-	"google.golang.org/protobuf/proto"
+	"google.golang.org/api/compute/v1"
 )
 
-var testConfig = &app.IMConfig{
+var testConfig = app.IMConfig{
 	GCP: &app.GCPIMConfig{
 		ProjectID: "google.com:test-project",
 		HostImage: "projects/test-project-releases/global/images/img-001",
 	},
 }
+
+var testNameGenerator = &testConstantNameGenerator{name: "foo"}
 
 type TestUserInfo struct{}
 
@@ -48,11 +47,15 @@ func (i *TestUserInfo) Username() string {
 
 func TestCreateHostInvalidRequests(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		replyJSON(w, &computepb.Operation{})
+		replyJSON(w, &compute.Operation{})
 	}))
 	defer ts.Close()
-	im := newTestInstanceManager(t, ts)
-	defer im.Close()
+	im := InstanceManager{
+		Config:                testConfig,
+		Client:                ts.Client(),
+		InstanceNameGenerator: testNameGenerator,
+		ServiceURL:            ts.URL,
+	}
 	var validRequest = func() *apiv1.CreateHostRequest {
 		return &apiv1.CreateHostRequest{
 			CreateHostInstanceRequest: &apiv1.CreateHostInstanceRequest{
@@ -67,7 +70,7 @@ func TestCreateHostInvalidRequests(t *testing.T) {
 	// Make sure the valid request is indeed valid.
 	_, err := im.CreateHost("us-central1-a", validRequest(), &TestUserInfo{})
 	if err != nil {
-		t.Fatalf("the valid request is not valid")
+		t.Fatalf("the valid request is not valid with error %+v", err)
 	}
 	var tests = []struct {
 		corruptRequest func(r *apiv1.CreateHostRequest)
@@ -93,11 +96,15 @@ func TestCreateHostRequestPath(t *testing.T) {
 	var pathSent string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		pathSent = r.URL.Path
-		replyJSON(w, &computepb.Operation{})
+		replyJSON(w, &compute.Operation{})
 	}))
 	defer ts.Close()
-	im := newTestInstanceManager(t, ts)
-	defer im.Close()
+	im := InstanceManager{
+		Config:                testConfig,
+		Client:                ts.Client(),
+		InstanceNameGenerator: testNameGenerator,
+		ServiceURL:            ts.URL,
+	}
 
 	im.CreateHost("us-central1-a",
 		&apiv1.CreateHostRequest{
@@ -111,7 +118,7 @@ func TestCreateHostRequestPath(t *testing.T) {
 		},
 		&TestUserInfo{})
 
-	expected := "/compute/v1/projects/google.com:test-project/zones/us-central1-a/instances"
+	expected := "/projects/google.com:test-project/zones/us-central1-a/instances"
 	if pathSent != expected {
 		t.Errorf("unexpected url path <<%s>>, want: %s", pathSent, expected)
 	}
@@ -124,12 +131,15 @@ func TestCreateHostRequestBody(t *testing.T) {
 		if err == nil {
 			bodySent = b
 		}
-		replyJSON(w, &computepb.Operation{Name: proto.String("operation-16482")})
+		replyJSON(w, &compute.Operation{Name: "operation-1"})
 	}))
 	defer ts.Close()
-	im := newTestInstanceManager(t, ts)
-	im.setUUIDFactory(func() string { return "123e4567" })
-	defer im.Close()
+	im := InstanceManager{
+		Config:                testConfig,
+		Client:                ts.Client(),
+		InstanceNameGenerator: testNameGenerator,
+		ServiceURL:            ts.URL,
+	}
 
 	im.CreateHost("us-central1-a",
 		&apiv1.CreateHostRequest{
@@ -159,7 +169,7 @@ func TestCreateHostRequestBody(t *testing.T) {
   },
   "machineType": "zones/us-central1-f/machineTypes/n1-standard-1",
   "minCpuPlatform": "Intel Haswell",
-  "name": "cf-123e4567",
+  "name": "foo",
   "networkInterfaces": [
     {
       "accessConfigs": [
@@ -171,7 +181,8 @@ func TestCreateHostRequestBody(t *testing.T) {
       "name": "projects/google.com:test-project/global/networks/default"
     }
   ]
-}`
+}
+`
 	r := prettyJSON(t, bodySent)
 	if r != expected {
 		t.Errorf("unexpected body, diff: %s", diffPrettyText(r, expected))
@@ -179,16 +190,21 @@ func TestCreateHostRequestBody(t *testing.T) {
 }
 
 func TestCreateHostSuccess(t *testing.T) {
+	expectedName := "operation-1"
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		o := &computepb.Operation{
-			Name:   proto.String("operation-123"),
-			Status: computepb.Operation_DONE.Enum(),
+		o := &compute.Operation{
+			Name:   expectedName,
+			Status: "DONE",
 		}
 		replyJSON(w, o)
 	}))
 	defer ts.Close()
-	im := newTestInstanceManager(t, ts)
-	defer im.Close()
+	im := InstanceManager{
+		Config:                testConfig,
+		Client:                ts.Client(),
+		InstanceNameGenerator: testNameGenerator,
+		ServiceURL:            ts.URL,
+	}
 
 	op, _ := im.CreateHost("us-central1-a",
 		&apiv1.CreateHostRequest{
@@ -202,9 +218,11 @@ func TestCreateHostSuccess(t *testing.T) {
 		},
 		&TestUserInfo{})
 
-	expected := &apiv1.Operation{Name: "operation-123", Done: true}
-	if *op != *expected {
-		t.Errorf("unexpected operation: <<%v>>, want: %v", *op, *expected)
+	if op.Name != expectedName {
+		t.Errorf("expected <<%q>>, got: %q", expectedName, op.Name)
+	}
+	if !op.Done {
+		t.Error("expected true")
 	}
 }
 
@@ -212,15 +230,19 @@ func TestGetHostAddrRequestPath(t *testing.T) {
 	var pathSent string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		pathSent = r.URL.Path
-		replyJSON(w, &computepb.Instance{})
+		replyJSON(w, &compute.Instance{})
 	}))
 	defer ts.Close()
-	im := newTestInstanceManager(t, ts)
-	defer im.Close()
+	im := InstanceManager{
+		Config:                testConfig,
+		Client:                ts.Client(),
+		InstanceNameGenerator: testNameGenerator,
+		ServiceURL:            ts.URL,
+	}
 
-	im.GetHostAddr("us-central1-a", "cf-123e4567")
+	im.GetHostAddr("us-central1-a", "foo")
 
-	expected := "/compute/v1/projects/google.com:test-project/zones/us-central1-a/instances/cf-123e4567"
+	expected := "/projects/google.com:test-project/zones/us-central1-a/instances/foo"
 	if pathSent != expected {
 		t.Errorf("unexpected url path <<%q>>, want: %q", pathSent, expected)
 	}
@@ -228,13 +250,17 @@ func TestGetHostAddrRequestPath(t *testing.T) {
 
 func TestGetHostAddrMissingNetworkInterface(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		replyJSON(w, &computepb.Instance{})
+		replyJSON(w, &compute.Instance{})
 	}))
 	defer ts.Close()
-	im := newTestInstanceManager(t, ts)
-	defer im.Close()
+	im := InstanceManager{
+		Config:                testConfig,
+		Client:                ts.Client(),
+		InstanceNameGenerator: testNameGenerator,
+		ServiceURL:            ts.URL,
+	}
 
-	_, err := im.GetHostAddr("us-central1-a", "cf-123e4567")
+	_, err := im.GetHostAddr("us-central1-a", "foo")
 
 	var appErr *app.AppError
 	if !errors.As(err, &appErr) {
@@ -243,38 +269,30 @@ func TestGetHostAddrMissingNetworkInterface(t *testing.T) {
 }
 
 func TestGetHostAddrSuccess(t *testing.T) {
+	expectedIP := "10.128.0.63"
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		i := &computepb.Instance{
-			NetworkInterfaces: []*computepb.NetworkInterface{
+		i := &compute.Instance{
+			NetworkInterfaces: []*compute.NetworkInterface{
 				{
-					NetworkIP: proto.String("10.128.0.63"),
+					NetworkIP: expectedIP,
 				},
 			},
 		}
 		replyJSON(w, i)
 	}))
 	defer ts.Close()
-	im := newTestInstanceManager(t, ts)
-	defer im.Close()
-
-	addr, _ := im.GetHostAddr("us-central1-a", "cf-123e4567")
-
-	expected := "10.128.0.63"
-	if addr != expected {
-		t.Errorf("unexpected host address <<%q>>, want: %q", addr, expected)
+	im := InstanceManager{
+		Config:                testConfig,
+		Client:                ts.Client(),
+		InstanceNameGenerator: testNameGenerator,
+		ServiceURL:            ts.URL,
 	}
-}
 
-func newTestInstanceManager(t *testing.T, s *httptest.Server) *InstanceManager {
-	im, err := NewInstanceManager(
-		testConfig,
-		context.TODO(),
-		option.WithEndpoint(s.URL),
-		option.WithHTTPClient(s.Client()))
-	if err != nil {
-		t.Fatalf("failed to create new test GCPInstanceManager with error: %v", err)
+	addr, _ := im.GetHostAddr("us-central1-a", "foo")
+
+	if addr != expectedIP {
+		t.Errorf("unexpected host address <<%q>>, want: %q", addr, expectedIP)
 	}
-	return im
 }
 
 func prettyJSON(t *testing.T, b []byte) string {
@@ -295,4 +313,12 @@ func replyJSON(w http.ResponseWriter, obj interface{}) error {
 	w.Header().Set("Content-Type", "application/json")
 	encoder := json.NewEncoder(w)
 	return encoder.Encode(obj)
+}
+
+type testConstantNameGenerator struct {
+	name string
+}
+
+func (g *testConstantNameGenerator) NewName() string {
+	return g.name
 }

--- a/app/types.go
+++ b/app/types.go
@@ -50,8 +50,6 @@ type InstanceManager interface {
 	GetHostAddr(zone string, host string) (string, error)
 	// Creates a host instance.
 	CreateHost(zone string, req *apiv1.CreateHostRequest, user UserInfo) (*apiv1.Operation, error)
-	// Closes the connection with the underlying API
-	Close() error
 }
 
 type AuthHTTPHandler func(http.ResponseWriter, *http.Request, UserInfo) error

--- a/app/unix/instancemanager.go
+++ b/app/unix/instancemanager.go
@@ -32,5 +32,3 @@ func (d *InstanceManager) GetHostAddr(_ string, _ string) (string, error) {
 func (d *InstanceManager) CreateHost(_ string, _ *apiv1.CreateHostRequest, _ app.UserInfo) (*apiv1.Operation, error) {
 	return nil, app.NewInternalError(fmt.Sprintf("%T#CreateHost is not implemented", *d), nil)
 }
-
-func (d *InstanceManager) Close() error { return nil }


### PR DESCRIPTION
- Replaces the use of experimental package `google.golang.org/genproto/googleapis/cloud/compute/v1`.