### PR TITLE
Revert "Use acloud ownership label. (#24)"

### DIFF
--- a/app/gcp/instancemanager.go
+++ b/app/gcp/instancemanager.go
@@ -132,7 +132,7 @@ func (m *InstanceManager) ListHosts(zone string, user app.UserInfo, req *app.Lis
 		Context(context.TODO()).
 		MaxResults(int64(maxResults)).
 		PageToken(req.PageToken).
-		Filter(fmt.Sprintf("labels.%s:%s", labelCreatedBy, user.Username())).
+		Filter("labels.cf-created_by:" + user.Username()).
 		Do()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This reverts commit de5bbbbfe4d7ba197bcf5bd80b6ef37a41ea29ff.

- Not the acloud ownership label.