### PR TITLE
[api] Change Operation response type to string.

### DIFF
--- a/api/v1/instancemanager.go
+++ b/api/v1/instancemanager.go
@@ -35,11 +35,11 @@ type Operation struct {
 type OperationResult struct {
 	// The error result of the operation in case of failure or cancellation.
 	Error *Error `json:"error,omitempty"`
-	// The expected response of the operation in case of success.  If the original
-	// method returns no data on success, such as `Delete`, this field will be
-	// empty, hence omitted. If the original method is standard:
-	// `Get`/`Create`/`Update`, the response should be the relevant resource.
-	Response interface{} `json:"response,omitempty"`
+	// The expected response of the operation in case of success.  If the original method returns
+	// no data on success, such as `Delete`, this field will be empty, hence omitted. If the original
+	// method is standard: `Get`/`Create`/`Update`, the response should be the relevant resource
+	// encoded in JSON format.
+	Response string `json:"response,omitempty"`
 }
 
 type Error struct {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go/compute v1.5.0 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/go-cmp v0.5.7 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.1.1 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,7 @@ github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=

--- a/pkg/app/gcp/instancemanager.go
+++ b/pkg/app/gcp/instancemanager.go
@@ -16,6 +16,7 @@ package gcp
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/url"
@@ -277,7 +278,7 @@ func (b *operationBuilder) buildDone() (*apiv1.Operation, error) {
 		return &apiv1.Operation{
 			Name:   b.Operation.Name,
 			Done:   true,
-			Result: &apiv1.OperationResult{Response: struct{}{}},
+			Result: &apiv1.OperationResult{},
 		}, nil
 	} else if b.isCreateInstance() {
 		result, err := b.buildCreateInstanceResult()
@@ -321,5 +322,9 @@ func (b *operationBuilder) buildCreateInstanceResult() (*apiv1.OperationResult, 
 	if err != nil {
 		return nil, err
 	}
-	return &apiv1.OperationResult{Response: hostInstance}, nil
+	buf, err := json.Marshal(hostInstance)
+	if err != nil {
+		return nil, err
+	}
+	return &apiv1.OperationResult{Response: string(buf)}, nil
 }

--- a/pkg/app/gcp/instancemanager_test.go
+++ b/pkg/app/gcp/instancemanager_test.go
@@ -30,6 +30,7 @@ import (
 	apiv1 "github.com/google/cloud-android-orchestration/api/v1"
 	"github.com/google/cloud-android-orchestration/pkg/app"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/sergi/go-diff/diffmatchpatch"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/option"
@@ -547,10 +548,11 @@ func TestWaitCreateInstanceOperationSucceeds(t *testing.T) {
 	if !op.Done {
 		t.Error("expected done.")
 	}
-	expected, _ := BuildHostInstance(instance)
-	if !reflect.DeepEqual(op.Result.Response, expected) {
-		t.Errorf("unexpected operation result with diff: %s",
-			diffPrettyText(prettyJSON(t, *expected), prettyJSON(t, *instance)))
+	want, _ := BuildHostInstance(instance)
+	var got apiv1.HostInstance
+	json.Unmarshal([]byte(op.Result.Response), &got)
+	if diff := cmp.Diff(*want, got); diff != "" {
+		t.Errorf("operation response mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -581,8 +583,8 @@ func TestWaitDeleteInstanceOperationSucceeds(t *testing.T) {
 	if !op.Done {
 		t.Error("expected done.")
 	}
-	if op.Result.Response != struct{}{} {
-		t.Errorf("expected empty struct, got %+v", op.Result.Response)
+	if op.Result.Response != "" {
+		t.Errorf("expected empty string, got %q", op.Result.Response)
 	}
 }
 


### PR DESCRIPTION
- Use string to properly encode the embedded objects.