### PR TITLE
[orchestrator] Change wait operation response.

### DIFF
--- a/api/v1/instancemanager.go
+++ b/api/v1/instancemanager.go
@@ -32,7 +32,7 @@ type Operation struct {
 	// available.
 	Done bool `json:"done"`
 	// Result will contain either an error or a result object but never both.
-	Result *OperationResult `json:"result,omitempty"`
+	// Result *OperationResult `json:"result,omitempty"`
 }
 
 type OperationResult struct {

--- a/api/v1/instancemanager.go
+++ b/api/v1/instancemanager.go
@@ -31,8 +31,6 @@ type Operation struct {
 	// If `true`, the operation is completed, and either `error` or `response` is
 	// available.
 	Done bool `json:"done"`
-	// Result will contain either an error or a result object but never both.
-	// Result *OperationResult `json:"result,omitempty"`
 }
 
 type OperationResult struct {

--- a/pkg/app/controller.go
+++ b/pkg/app/controller.go
@@ -64,6 +64,12 @@ func (c *Controller) Handler() http.Handler {
 	// Instance Manager Routes
 	router.Handle("/v1/zones/{zone}/hosts", c.createHostHTTPHandler()).Methods("POST")
 	router.Handle("/v1/zones/{zone}/hosts", HTTPHandler(c.accountManager.Authenticate(c.listHosts))).Methods("GET")
+	// Waits for the specified operation to be DONE or for the request to approach the specified deadline,
+	// `503 Service Unavailable` error will be returned if the deadline is reached and the operation is not done.
+	// Be prepared to retry if the deadline was reached.
+	// It returns the expected response of the operation in case of success. If the original method returns no
+	// data on success, such as `Delete`, response will be empty. If the original method is standard
+	// `Get`/`Create`/`Update`, the response should be the relevant resource.
 	router.Handle("/v1/zones/{zone}/operations/{operation}/:wait", HTTPHandler(c.accountManager.Authenticate(c.waitOperation))).Methods("POST")
 	router.Handle("/v1/zones/{zone}/hosts/{host}", HTTPHandler(c.accountManager.Authenticate(c.deleteHost))).Methods("DELETE")
 

--- a/pkg/app/controller_test.go
+++ b/pkg/app/controller_test.go
@@ -68,8 +68,8 @@ func (m *testInstanceManager) DeleteHost(zone string, user UserInfo, name string
 	return &apiv1.Operation{}, nil
 }
 
-func (m *testInstanceManager) WaitOperation(_ string, _ UserInfo, _ string) (*apiv1.Operation, error) {
-	return &apiv1.Operation{}, nil
+func (m *testInstanceManager) WaitOperation(_ string, _ UserInfo, _ string) (interface{}, error) {
+	return struct{}{}, nil
 }
 
 func TestCreateHostSucceeds(t *testing.T) {

--- a/pkg/app/errors.go
+++ b/pkg/app/errors.go
@@ -66,3 +66,7 @@ func NewInternalError(msg string, e error) error {
 func NewForbiddenError(msg string, e error) error {
 	return &AppError{Msg: msg, StatusCode: http.StatusForbidden, Err: e}
 }
+
+func NewServiceUnavailableError(msg string, e error) error {
+	return &AppError{Msg: msg, StatusCode: http.StatusServiceUnavailable, Err: e}
+}

--- a/pkg/app/types.go
+++ b/pkg/app/types.go
@@ -57,8 +57,10 @@ type InstanceManager interface {
 	ListHosts(zone string, user UserInfo, req *ListHostsRequest) (*apiv1.ListHostsResponse, error)
 	// Deletes the given host instance.
 	DeleteHost(zone string, user UserInfo, name string) (*apiv1.Operation, error)
-	// Waits until operation is DONE or earlier returning the current status.
-	WaitOperation(zone string, user UserInfo, name string) (*apiv1.Operation, error)
+	// Waits until operation is DONE or earlier. If DONE return the expected  response of the operation. If the
+	// original method returns no data on success, such as `Delete`, response will be empty. If the original method
+	// is standard `Get`/`Create`/`Update`, the response should be the relevant resource.
+	WaitOperation(zone string, user UserInfo, name string) (interface{}, error)
 }
 
 type ListHostsRequest struct {

--- a/pkg/app/unix/instancemanager.go
+++ b/pkg/app/unix/instancemanager.go
@@ -56,6 +56,6 @@ func (m *InstanceManager) DeleteHost(zone string, user app.UserInfo, name string
 	return nil, app.NewInternalError(fmt.Sprintf("%T#DeleteHost is not implemented", *m), nil)
 }
 
-func (m *InstanceManager) WaitOperation(zone string, user app.UserInfo, name string) (*apiv1.Operation, error) {
+func (m *InstanceManager) WaitOperation(zone string, user app.UserInfo, name string) (interface{}, error) {
 	return nil, app.NewInternalError(fmt.Sprintf("%T#WaitOperation is not implemented", *m), nil)
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -75,21 +75,11 @@ func (c *APIClient) CreateHost(req *apiv1.CreateHostRequest) (*apiv1.HostInstanc
 		return nil, err
 	}
 	path := "/operations/" + op.Name + "/:wait"
-	if err := c.doRequest("POST", path, nil, &op); err != nil {
+	ins := &apiv1.HostInstance{}
+	if err := c.doRequest("POST", path, nil, ins); err != nil {
 		return nil, err
 	}
-	if op.Result != nil && op.Result.Error != nil {
-		err := &ApiCallError{op.Result.Error}
-		return nil, err
-	}
-	if !op.Done {
-		return nil, OpTimeoutError(op.Name)
-	}
-	var ins apiv1.HostInstance
-	if err := json.Unmarshal([]byte(op.Result.Response), &ins); err != nil {
-		return nil, err
-	}
-	return &ins, nil
+	return ins, nil
 }
 
 func (c *APIClient) ListHosts() (*apiv1.ListHostsResponse, error) {


### PR DESCRIPTION
- Return the direct result or error rather than the whole operation, having the responses for failed operations be aligned with the relevant http status code.
- Remove result property from operation object to avoid the result being queried this way.