### PR TITLE
Use runtime go119 for app engine

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-runtime: go116
+runtime: go119
 
 main: ./cmd/cloud_orchestrator


### PR DESCRIPTION
It fails to build with 1.16 because of a dependency Version 1.19 matches the github actions.