### PR TITLE
Fix value of Min CPU platform to "Intel Haswell".

### DIFF
--- a/api/v1/instancemanager.go
+++ b/api/v1/instancemanager.go
@@ -18,8 +18,6 @@ type GCPInstance struct {
 	// [REQUIRED] Specifies the machine type of the VM Instance.
 	// Check https://cloud.google.com/compute/docs/regions-zones#available for available values.
 	MachineType string `json:"machine_type"`
-	// Specifies a minimum CPU platform for the VM instance.
-	MinCPUPlatform string `json:"min_cpu_platform"`
 }
 
 type Operation struct {

--- a/pkg/app/gcp/instancemanager_test.go
+++ b/pkg/app/gcp/instancemanager_test.go
@@ -66,8 +66,7 @@ func TestCreateHostInvalidRequests(t *testing.T) {
 		return &apiv1.CreateHostRequest{
 			HostInstance: &apiv1.HostInstance{
 				GCP: &apiv1.GCPInstance{
-					MachineType:    "n1-standard-1",
-					MinCPUPlatform: "Intel Haswell",
+					MachineType: "n1-standard-1",
 				},
 			},
 		}
@@ -116,8 +115,7 @@ func TestCreateHostRequestPath(t *testing.T) {
 		&apiv1.CreateHostRequest{
 			HostInstance: &apiv1.HostInstance{
 				GCP: &apiv1.GCPInstance{
-					MachineType:    "n1-standard-1",
-					MinCPUPlatform: "Intel Haswell",
+					MachineType: "n1-standard-1",
 				},
 			},
 		},
@@ -148,14 +146,16 @@ func TestCreateHostRequestBody(t *testing.T) {
 		&apiv1.CreateHostRequest{
 			HostInstance: &apiv1.HostInstance{
 				GCP: &apiv1.GCPInstance{
-					MachineType:    "n1-standard-1",
-					MinCPUPlatform: "Intel Haswell",
+					MachineType: "n1-standard-1",
 				},
 			},
 		},
 		&TestUserInfo{})
 
 	expected := `{
+  "advancedMachineFeatures": {
+    "enableNestedVirtualization": true
+  },
   "disks": [
     {
       "boot": true,
@@ -210,8 +210,7 @@ func TestCreateHostSuccess(t *testing.T) {
 		&apiv1.CreateHostRequest{
 			HostInstance: &apiv1.HostInstance{
 				GCP: &apiv1.GCPInstance{
-					MachineType:    "n1-standard-1",
-					MinCPUPlatform: "Intel Haswell",
+					MachineType: "n1-standard-1",
 				},
 			},
 		},
@@ -660,8 +659,7 @@ func TestBuildHostInstance(t *testing.T) {
 		Name:           "foo",
 		BootDiskSizeGB: 10,
 		GCP: &apiv1.GCPInstance{
-			MachineType:    "n1-standard-1",
-			MinCPUPlatform: "Intel Haswell",
+			MachineType: "n1-standard-1",
 		},
 	}
 	if diff := cmp.Diff(&want, got); diff != "" {

--- a/pkg/cli/host.go
+++ b/pkg/cli/host.go
@@ -25,8 +25,7 @@ import (
 )
 
 const (
-	gcpMachineTypeFlag    = "gcp_machine_type"
-	gcpMinCPUPlatformFlag = "gcp_min_cpu_platform"
+	gcpMachineTypeFlag = "gcp_machine_type"
 )
 
 type createGCPHostFlags struct {
@@ -48,10 +47,8 @@ func newHostCommand(cfgFlags *configFlags) *cobra.Command {
 			return runCreateHostCommand(createFlags, c, args)
 		},
 	}
-	create.Flags().StringVar(&createFlags.MachineType, gcpMachineTypeFlag, "e2-standard-4",
+	create.Flags().StringVar(&createFlags.MachineType, gcpMachineTypeFlag, "n1-standard-4",
 		"Indicates the machine type")
-	create.Flags().StringVar(&createFlags.MinCPUPlatform, gcpMinCPUPlatformFlag, "",
-		"Specifies a minimum CPU platform for the VM instance")
 	list := &cobra.Command{
 		Use:   "list",
 		Short: "Lists hosts.",
@@ -85,8 +82,7 @@ func runCreateHostCommand(flags *createGCPHostFlags, c *cobra.Command, _ []strin
 	req := apiv1.CreateHostRequest{
 		HostInstance: &apiv1.HostInstance{
 			GCP: &apiv1.GCPInstance{
-				MachineType:    flags.MachineType,
-				MinCPUPlatform: flags.MinCPUPlatform,
+				MachineType: flags.MachineType,
 			},
 		},
 	}


### PR DESCRIPTION
- "Intel Haswell" is required as min cpu platform in order to enable nested virtualization. https://cloud.google.com/compute/docs/instances/nested-virtualization/enabling
- Remove the ability to set this parameter from clients.