### PR TITLE
Revert "Fix value of Min CPU platform to "Intel Haswell"."

### DIFF
--- a/api/v1/instancemanager.go
+++ b/api/v1/instancemanager.go
@@ -18,6 +18,8 @@ type GCPInstance struct {
 	// [REQUIRED] Specifies the machine type of the VM Instance.
 	// Check https://cloud.google.com/compute/docs/regions-zones#available for available values.
 	MachineType string `json:"machine_type"`
+	// Specifies a minimum CPU platform for the VM instance.
+	MinCPUPlatform string `json:"min_cpu_platform"`
 }
 
 type Operation struct {

--- a/pkg/app/gcp/instancemanager.go
+++ b/pkg/app/gcp/instancemanager.go
@@ -85,7 +85,8 @@ func (m *InstanceManager) CreateHost(zone string, req *apiv1.CreateHostRequest, 
 		Name: m.InstanceNameGenerator.NewName(),
 		// This is required in the format: "zones/zone/machineTypes/machine-type".
 		// Read more: https://cloud.google.com/compute/docs/reference/rest/v1/instances/insert#request-body
-		MachineType: fmt.Sprintf("zones/%s/machineTypes/%s", zone, req.HostInstance.GCP.MachineType),
+		MachineType:    fmt.Sprintf("zones/%s/machineTypes/%s", zone, req.HostInstance.GCP.MachineType),
+		MinCpuPlatform: req.HostInstance.GCP.MinCPUPlatform,
 		Disks: []*compute.AttachedDisk{
 			{
 				InitializeParams: &compute.AttachedDiskInitializeParams{
@@ -106,12 +107,6 @@ func (m *InstanceManager) CreateHost(zone string, req *apiv1.CreateHostRequest, 
 			},
 		},
 		Labels: labels,
-		// Required to enable nested virtualization
-		// https://cloud.google.com/compute/docs/instances/nested-virtualization/enabling#enabling_nested_virtualization_directly_on_a_new_vm
-		MinCpuPlatform: "Intel Haswell",
-		AdvancedMachineFeatures: &compute.AdvancedMachineFeatures{
-			EnableNestedVirtualization: true,
-		},
 	}
 	op, err := m.Service.Instances.
 		Insert(m.Config.GCP.ProjectID, zone, payload).
@@ -229,7 +224,8 @@ func BuildHostInstance(in *compute.Instance) (*apiv1.HostInstance, error) {
 		Name:           in.Name,
 		BootDiskSizeGB: in.Disks[0].DiskSizeGb,
 		GCP: &apiv1.GCPInstance{
-			MachineType: path.Base(in.MachineType),
+			MachineType:    path.Base(in.MachineType),
+			MinCPUPlatform: in.MinCpuPlatform,
 		},
 	}, nil
 }

--- a/pkg/app/gcp/instancemanager_test.go
+++ b/pkg/app/gcp/instancemanager_test.go
@@ -66,7 +66,8 @@ func TestCreateHostInvalidRequests(t *testing.T) {
 		return &apiv1.CreateHostRequest{
 			HostInstance: &apiv1.HostInstance{
 				GCP: &apiv1.GCPInstance{
-					MachineType: "n1-standard-1",
+					MachineType:    "n1-standard-1",
+					MinCPUPlatform: "Intel Haswell",
 				},
 			},
 		}
@@ -115,7 +116,8 @@ func TestCreateHostRequestPath(t *testing.T) {
 		&apiv1.CreateHostRequest{
 			HostInstance: &apiv1.HostInstance{
 				GCP: &apiv1.GCPInstance{
-					MachineType: "n1-standard-1",
+					MachineType:    "n1-standard-1",
+					MinCPUPlatform: "Intel Haswell",
 				},
 			},
 		},
@@ -146,16 +148,14 @@ func TestCreateHostRequestBody(t *testing.T) {
 		&apiv1.CreateHostRequest{
 			HostInstance: &apiv1.HostInstance{
 				GCP: &apiv1.GCPInstance{
-					MachineType: "n1-standard-1",
+					MachineType:    "n1-standard-1",
+					MinCPUPlatform: "Intel Haswell",
 				},
 			},
 		},
 		&TestUserInfo{})
 
 	expected := `{
-  "advancedMachineFeatures": {
-    "enableNestedVirtualization": true
-  },
   "disks": [
     {
       "boot": true,
@@ -210,7 +210,8 @@ func TestCreateHostSuccess(t *testing.T) {
 		&apiv1.CreateHostRequest{
 			HostInstance: &apiv1.HostInstance{
 				GCP: &apiv1.GCPInstance{
-					MachineType: "n1-standard-1",
+					MachineType:    "n1-standard-1",
+					MinCPUPlatform: "Intel Haswell",
 				},
 			},
 		},
@@ -659,7 +660,8 @@ func TestBuildHostInstance(t *testing.T) {
 		Name:           "foo",
 		BootDiskSizeGB: 10,
 		GCP: &apiv1.GCPInstance{
-			MachineType: "n1-standard-1",
+			MachineType:    "n1-standard-1",
+			MinCPUPlatform: "Intel Haswell",
 		},
 	}
 	if diff := cmp.Diff(&want, got); diff != "" {

--- a/pkg/cli/host.go
+++ b/pkg/cli/host.go
@@ -25,7 +25,8 @@ import (
 )
 
 const (
-	gcpMachineTypeFlag = "gcp_machine_type"
+	gcpMachineTypeFlag    = "gcp_machine_type"
+	gcpMinCPUPlatformFlag = "gcp_min_cpu_platform"
 )
 
 type createGCPHostFlags struct {
@@ -47,8 +48,10 @@ func newHostCommand(cfgFlags *configFlags) *cobra.Command {
 			return runCreateHostCommand(createFlags, c, args)
 		},
 	}
-	create.Flags().StringVar(&createFlags.MachineType, gcpMachineTypeFlag, "n1-standard-4",
+	create.Flags().StringVar(&createFlags.MachineType, gcpMachineTypeFlag, "e2-standard-4",
 		"Indicates the machine type")
+	create.Flags().StringVar(&createFlags.MinCPUPlatform, gcpMinCPUPlatformFlag, "",
+		"Specifies a minimum CPU platform for the VM instance")
 	list := &cobra.Command{
 		Use:   "list",
 		Short: "Lists hosts.",
@@ -82,7 +85,8 @@ func runCreateHostCommand(flags *createGCPHostFlags, c *cobra.Command, _ []strin
 	req := apiv1.CreateHostRequest{
 		HostInstance: &apiv1.HostInstance{
 			GCP: &apiv1.GCPInstance{
-				MachineType: flags.MachineType,
+				MachineType:    flags.MachineType,
+				MinCPUPlatform: flags.MinCPUPlatform,
 			},
 		},
 	}


### PR DESCRIPTION
Reverts google/cloud-android-orchestration#79

Reverting because setting "Intel Haswell"  as Min CPU platform is only required for n1-* family.