### PR TITLE
[cli] Changes gcp machine type default to "n1-standard-4".

### DIFF
--- a/pkg/cli/host.go
+++ b/pkg/cli/host.go
@@ -48,7 +48,7 @@ func newHostCommand(cfgFlags *configFlags) *cobra.Command {
 			return runCreateHostCommand(createFlags, c, args)
 		},
 	}
-	create.Flags().StringVar(&createFlags.MachineType, gcpMachineTypeFlag, "e2-standard-4",
+	create.Flags().StringVar(&createFlags.MachineType, gcpMachineTypeFlag, "n1-standard-4",
 		"Indicates the machine type")
 	create.Flags().StringVar(&createFlags.MinCPUPlatform, gcpMinCPUPlatformFlag, "",
 		"Specifies a minimum CPU platform for the VM instance")


### PR DESCRIPTION
- Former "e2-standard-4" type does not have nested virtualization enabled out of the box.