### PR TITLE
Make cvdremote client configurable

### DIFF
--- a/pkg/cli/adbtunnel.go
+++ b/pkg/cli/adbtunnel.go
@@ -183,7 +183,7 @@ func (f *ADBForwarder) OnClose() {
 func (f *ADBForwarder) StartForwarding() error {
 	listener, err := net.Listen("tcp", "127.0.0.1:")
 	if err != nil {
-		return err
+		return fmt.Errorf("Error listening on port: %w", err)
 	}
 	f.listener = listener
 	f.running.Store(true)

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -129,7 +129,11 @@ func buildAPIClient(flags *subCommandFlags, c *cobra.Command) (*client.APIClient
 		RetryAttempts: 3,
 		RetryDelay:    5 * time.Second,
 	}
-	return client.NewAPIClient(opts)
+	apiClient, err := client.NewAPIClient(opts)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to build API client: %w", err)
+	}
+	return apiClient, nil
 }
 
 func addCommonSubcommandFlags(c *cobra.Command, flags *subCommandFlags) {

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -17,6 +17,7 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -151,8 +152,8 @@ func TestCommandFails(t *testing.T) {
 			if diff := cmp.Diff(test.ExpOut, string(b)); diff != "" {
 				t.Errorf("standard output mismatch (-want +got):\n%s", diff)
 			}
-			if diff := cmp.Diff(test.ExpErr, err); diff != "" {
-				t.Errorf("err mismatch (-want +got):\n%s", diff)
+			if !errors.Is(err, test.ExpErr) {
+				t.Errorf("err mismatch (-want +got):\n-%v\n+%v", test.ExpErr, err)
 			}
 		})
 	}

--- a/pkg/cli/config.go
+++ b/pkg/cli/config.go
@@ -1,0 +1,45 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"io"
+
+	toml "github.com/pelletier/go-toml"
+)
+
+type GCPHostConfig struct {
+	DefaultMachineType    string
+	DefaultMinCPUPlatform string
+}
+
+type HostConfig struct {
+	GCP GCPHostConfig
+}
+
+type Config struct {
+	DefaultServiceURL string
+	DefaultZone       string
+	DefaultHTTPProxy  string
+	Host              HostConfig
+}
+
+func ParseConfig(config *Config, confFile io.Reader) error {
+	decoder := toml.NewDecoder(confFile)
+	// Fail if there is some unknown configuration. This is better than silently
+	// ignoring a (perhaps mispelled) config entry.
+	decoder.Strict(true)
+	return decoder.Decode(config)
+}

--- a/pkg/cli/config_test.go
+++ b/pkg/cli/config_test.go
@@ -1,0 +1,90 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+const (
+	validConfig = `
+DefaultServiceURL = "service_url"
+DefaultZone = "zone"
+DefaultHTTPProxy = "http_proxy"
+[Host.GCP]
+DefaultMachineType = "machine_type"
+DefaultMinCPUPlatform = "cpu_platform"
+`
+	invalidConfig = "foo_bar_baz = \"unknown field\""
+)
+
+func TestParseConfig(t *testing.T) {
+	// This test is little more than a change detector, however it's still
+	// useful to detect config parsing errors early, such as those introduced by
+	// a rename of the config properties.
+	var config Config
+	err := ParseConfig(&config, strings.NewReader(validConfig))
+	if err != nil {
+		t.Errorf("Failed to parse config: %v", err)
+	}
+	// It's not necessary to check the value of each property because a successful
+	// parsing of the valid config above and a failed parsing of the config with
+	// unknown properties below guarantee that all properties of the valid config
+	// were parsed. The parsing library doesn't need to be tested here.
+}
+
+func TestParseAllConfig(t *testing.T) {
+	var config Config
+	err := ParseConfig(&config, strings.NewReader(validConfig))
+	if err != nil {
+		t.SkipNow()
+	}
+	// Ensure no field was left unparsed. This will fail everytime a new field is
+	// added to cli.Config, just add it to the valid config above with a non zero
+	// value to make it pass and ensure these tests apply to that field in the
+	// future.
+	if has, f := HasZeroes(config); has {
+		t.Errorf("The Config's %s field was not parsed", f)
+	}
+}
+
+func TestParseInvalidConfig(t *testing.T) {
+	var config Config
+	err := ParseConfig(&config, strings.NewReader(invalidConfig))
+	if err == nil {
+		t.Errorf("Expected unknown config property to produce an error")
+	}
+}
+
+// Returns true if the argument or any field at any nest level is zero-valued.
+// It also returns the name of the first zero-valued field it finds.
+func HasZeroes(o any) (bool, string) {
+	value := reflect.ValueOf(o)
+	if value.Kind() != reflect.Struct {
+		return value.IsZero(), ""
+	}
+	for i := 0; i < value.NumField(); i++ {
+		if has, name := HasZeroes(value.Field(i).Interface()); has {
+			fullName := value.Type().Field(i).Name
+			if name != "" {
+				fullName += "." + name
+			}
+			return true, fullName
+		}
+	}
+	return false, ""
+}

--- a/pkg/cli/cvd.go
+++ b/pkg/cli/cvd.go
@@ -95,7 +95,7 @@ func runCreateCVDCommand(flags *createCVDFlags, c *cobra.Command, _ []string) er
 	}
 	cvd, err := apiClient.CreateCVD(flags.Host, &req)
 	if err != nil {
-		return err
+		return fmt.Errorf("Error creating CVD: %w", err)
 	}
 	c.Printf("%s\n", cvd.Name)
 	return nil
@@ -112,7 +112,7 @@ func runListCVDsCommand(flags *listCVDsFlags, c *cobra.Command, _ []string) erro
 	} else {
 		res, err := apiClient.ListHosts()
 		if err != nil {
-			return err
+			return fmt.Errorf("Error listing hosts: %w", err)
 		}
 		for _, host := range res.Items {
 			hosts = append(hosts, host.Name)

--- a/pkg/cli/host.go
+++ b/pkg/cli/host.go
@@ -35,7 +35,7 @@ type createGCPHostFlags struct {
 	MinCPUPlatform string
 }
 
-func newHostCommand(cfgFlags *configFlags) *cobra.Command {
+func newHostCommand(cfgFlags *configFlags, config *HostConfig) *cobra.Command {
 	hostFlags := &subCommandFlags{
 		cfgFlags,
 		false,
@@ -48,9 +48,10 @@ func newHostCommand(cfgFlags *configFlags) *cobra.Command {
 			return runCreateHostCommand(createFlags, c, args)
 		},
 	}
-	create.Flags().StringVar(&createFlags.MachineType, gcpMachineTypeFlag, "n1-standard-4",
-		"Indicates the machine type")
-	create.Flags().StringVar(&createFlags.MinCPUPlatform, gcpMinCPUPlatformFlag, "",
+	create.Flags().StringVar(&createFlags.MachineType, gcpMachineTypeFlag,
+		config.GCP.DefaultMachineType, "Indicates the machine type")
+	create.Flags().StringVar(&createFlags.MinCPUPlatform, gcpMinCPUPlatformFlag,
+		config.GCP.DefaultMinCPUPlatform,
 		"Specifies a minimum CPU platform for the VM instance")
 	list := &cobra.Command{
 		Use:   "list",

--- a/pkg/cli/host.go
+++ b/pkg/cli/host.go
@@ -92,7 +92,7 @@ func runCreateHostCommand(flags *createGCPHostFlags, c *cobra.Command, _ []strin
 	}
 	ins, err := apiClient.CreateHost(&req)
 	if err != nil {
-		return err
+		return fmt.Errorf("Error creating host: %w", err)
 	}
 	c.Printf("%s\n", ins.Name)
 	return nil
@@ -105,7 +105,7 @@ func runListHostsCommand(flags *subCommandFlags, c *cobra.Command, _ []string) e
 	}
 	hosts, err := apiClient.ListHosts()
 	if err != nil {
-		return err
+		return fmt.Errorf("Error listing hosts: %w", err)
 	}
 	for _, ins := range hosts.Items {
 		c.Printf("%s\n", ins.Name)


### PR DESCRIPTION
The `cvdremote` client can be configure with a file in toml format.
The file location is passed to the executable as an environment variable to allow for different locations depending on platform. Final users are not expected to pass this variable to the command, instead when the binary is distributed it should be wrapped in a way that ensures the variable is set with the appropriate path (for example, in debian `cvdremote` should point to a script that sets the variable and executes the binary)