### PR TITLE
[cvdremote] Allows to pass different `client.Service` implementations.

### DIFF
--- a/cmd/cvdremote/main.go
+++ b/cmd/cvdremote/main.go
@@ -19,6 +19,7 @@ import (
 	"os"
 
 	"github.com/google/cloud-android-orchestration/pkg/cli"
+	"github.com/google/cloud-android-orchestration/pkg/client"
 )
 
 const configPathVar = "CVDREMOTE_CONFIG_PATH"
@@ -43,8 +44,9 @@ func readConfig(config *cli.Config) error {
 
 func main() {
 	opts := &cli.CommandOptions{
-		IOStreams: cli.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr},
-		Args:      os.Args[1:],
+		IOStreams:      cli.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr},
+		Args:           os.Args[1:],
+		ServiceBuilder: client.NewService,
 	}
 
 	if err := readConfig(&opts.Config); err != nil {

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -142,8 +142,9 @@ func TestCommandFails(t *testing.T) {
 			defer ts.Close()
 			io, _, out := newTestIOStreams()
 			opts := &CommandOptions{
-				IOStreams: io,
-				Args:      append([]string{"--service_url=" + ts.URL}, test.Args[:]...),
+				IOStreams:      io,
+				Args:           append([]string{"--service_url=" + ts.URL}, test.Args[:]...),
+				ServiceBuilder: client.NewService,
 			}
 
 			err := NewCVDRemoteCommand(opts).Execute()
@@ -252,8 +253,9 @@ func TestCommandSucceeds(t *testing.T) {
 				t.Run("with config "+cfg.Name, func(t *testing.T) {
 					io, _, out := newTestIOStreams()
 					opts := &CommandOptions{
-						IOStreams: io,
-						Args:      append(cfg.Args, test.Args[:]...),
+						IOStreams:      io,
+						Args:           append(cfg.Args, test.Args[:]...),
+						ServiceBuilder: client.NewService,
 					}
 
 					err := NewCVDRemoteCommand(opts).Execute()
@@ -298,8 +300,9 @@ func TestDeleteHostsCommandFails(t *testing.T) {
 	defer ts.Close()
 	io, _, _ := newTestIOStreams()
 	opts := &CommandOptions{
-		IOStreams: io,
-		Args:      append([]string{"--service_url=" + ts.URL}, "host", "delete", "foo", "bar", "baz", "quz"),
+		IOStreams:      io,
+		Args:           append([]string{"--service_url=" + ts.URL}, "host", "delete", "foo", "bar", "baz", "quz"),
+		ServiceBuilder: client.NewService,
 	}
 
 	err := NewCVDRemoteCommand(opts).Execute()

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -48,13 +48,13 @@ func TestRetryLogic(t *testing.T) {
 
 	}))
 	defer ts.Close()
-	opts := &APIClientOptions{
+	opts := &ServiceOptions{
 		BaseURL:       ts.URL,
 		DumpOut:       io.Discard,
 		RetryAttempts: 2,
 		RetryDelay:    100 * time.Millisecond,
 	}
-	client, _ := NewAPIClient(opts)
+	client, _ := NewService(opts)
 
 	start := time.Now()
 	host, _ := client.CreateHost(&apiv1.CreateHostRequest{})


### PR DESCRIPTION
- Useful for unit testing.