### PR TITLE
[cli] Removes `Default` prefix in config parameters.

### DIFF
--- a/build/package/host/etc/cvdremote.toml
+++ b/build/package/host/etc/cvdremote.toml
@@ -5,15 +5,15 @@
 #  specify --service_url=<url> everytime.
 # The URL should be the full path to the service API without including the api
 # version, which will be appended by the cvdremote binary.
-# DefaultServiceURL = "https://cloud.android.company.com/api"
+# ServiceURL = "https://cloud.android.company.com/api"
 
 # The zone where the users' host VMs will be created. The value typically
 # depends on the Cloud Provider being used, the example below is for the Google
 # Cloud Platform.
-# DefaultZone = "us-central1-c"
+# Zone = "us-central1-c"
 
 # An (optional) HTTP proxy.
-# DefaultHTTPProxy = "http://proxy.company.com:123456"
+# HTTPProxy = "http://proxy.company.com:123456"
 
 # Directory where the control sockets for the ADB tunnels will be created and
 # log files will be placed. The directory path should be short enough for UNIX
@@ -28,6 +28,6 @@
 # Machine type to use for new hosts when the user doesn't specify one on the
 # command line. The machine type must support nested virtualization for CVDs to
 # be hosted on them.
-DefaultMachineType = "n1-standard-4"
+MachineType = "n1-standard-4"
 
-# DefaultMinCPUPlatform = ""
+# MinCPUPlatform = ""

--- a/cmd/cvdremote/main.go
+++ b/cmd/cvdremote/main.go
@@ -43,20 +43,20 @@ func readConfig(config *cli.Config) error {
 }
 
 func main() {
+	config := cli.DefaultConfig()
+	// Overrides relevant defaults with values set in config file.
+	if err := readConfig(&config); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
 	opts := &cli.CommandOptions{
 		IOStreams:      cli.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr},
 		Args:           os.Args[1:],
 		ServiceBuilder: client.NewService,
-		Config:         cli.DefaultConfig(),
+		InitialConfig:  config,
 	}
 
-	if err := readConfig(&opts.Config); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(2)
-	}
-
-	err := cli.NewCVDRemoteCommand(opts).Execute()
-	if err != nil {
+	if err := cli.NewCVDRemoteCommand(opts).Execute(); err != nil {
 		os.Exit(1)
 	}
 }

--- a/pkg/cli/adbtunnel.go
+++ b/pkg/cli/adbtunnel.go
@@ -111,7 +111,7 @@ func openADBTunnel(flags *OpenADBTunnelFlags, c *command, args []string, opts *s
 			device:     device,
 		}
 		controller, err := NewTunnelController(
-			opts.Config.ADBControlDir, service, devProps, logger)
+			opts.InitialConfig.ADBControlDir, service, devProps, logger)
 
 		if err != nil {
 			merr = multierror.Append(merr, err)

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -34,7 +34,7 @@ type IOStreams struct {
 type CommandOptions struct {
 	IOStreams
 	Args           []string
-	Config         Config
+	InitialConfig  Config
 	ServiceBuilder client.ServiceBuilder
 }
 
@@ -86,22 +86,21 @@ func NewCVDRemoteCommand(o *CommandOptions) *CVDRemoteCommand {
 	rootCmd.SetArgs(o.Args)
 	rootCmd.SetOut(o.IOStreams.Out)
 	rootCmd.SetErr(o.IOStreams.ErrOut)
-	rootCmd.PersistentFlags().StringVar(&flags.ServiceURL, serviceURLFlag,
-		o.Config.DefaultServiceURL, "Cloud orchestration service url.")
-	if o.Config.DefaultServiceURL == "" {
+	rootCmd.PersistentFlags().StringVar(&flags.ServiceURL, serviceURLFlag, o.InitialConfig.ServiceURL,
+		"Cloud orchestration service url.")
+	if o.InitialConfig.ServiceURL == "" {
 		// Make it required if not configured
 		rootCmd.MarkPersistentFlagRequired(serviceURLFlag)
 	}
-	rootCmd.PersistentFlags().StringVar(&flags.Zone, zoneFlag, o.Config.DefaultZone,
-		"Cloud zone.")
-	rootCmd.PersistentFlags().StringVar(&flags.HTTPProxy, httpProxyFlag,
-		o.Config.DefaultHTTPProxy, "Proxy used to route the http communication through.")
+	rootCmd.PersistentFlags().StringVar(&flags.Zone, zoneFlag, o.InitialConfig.Zone, "Cloud zone.")
+	rootCmd.PersistentFlags().StringVar(&flags.HTTPProxy, httpProxyFlag, o.InitialConfig.HTTPProxy,
+		"Proxy used to route the http communication through.")
 	// Do not show a `help` command, users have always the `-h` and `--help` flags for help purpose.
 	rootCmd.SetHelpCommand(&cobra.Command{Hidden: true})
 	subCmdOpts := &subCommandOpts{
 		ServiceBuilder: buildServiceBuilder(o.ServiceBuilder),
 		RootFlags:      flags,
-		Config:         &o.Config,
+		InitialConfig:  o.InitialConfig,
 	}
 	rootCmd.AddCommand(newHostCommand(subCmdOpts))
 	rootCmd.AddCommand(newADBTunnelCommand(subCmdOpts))
@@ -131,7 +130,7 @@ type serviceBuilder func(flags *CommonSubcmdFlags, c *cobra.Command) (client.Ser
 type subCommandOpts struct {
 	ServiceBuilder serviceBuilder
 	RootFlags      *CVDRemoteFlags
-	Config         *Config
+	InitialConfig  Config
 }
 
 const chunkSizeBytes = 16 * 1024 * 1024

--- a/pkg/cli/config.go
+++ b/pkg/cli/config.go
@@ -21,8 +21,8 @@ import (
 )
 
 type GCPHostConfig struct {
-	DefaultMachineType    string
-	DefaultMinCPUPlatform string
+	MachineType    string
+	MinCPUPlatform string
 }
 
 type HostConfig struct {
@@ -30,18 +30,16 @@ type HostConfig struct {
 }
 
 type Config struct {
-	DefaultServiceURL string
-	DefaultZone       string
-	DefaultHTTPProxy  string
-	ADBControlDir     string
-	Host              HostConfig
+	ServiceURL    string
+	Zone          string
+	HTTPProxy     string
+	ADBControlDir string
+	Host          HostConfig
 }
 
 func DefaultConfig() Config {
-	const defaultADBControlDir = "~/.cvdremote/adb"
-
 	return Config{
-		ADBControlDir: defaultADBControlDir,
+		ADBControlDir: "~/.cvdremote/adb",
 	}
 }
 

--- a/pkg/cli/config_test.go
+++ b/pkg/cli/config_test.go
@@ -22,12 +22,12 @@ import (
 
 const (
 	validConfig = `
-DefaultServiceURL = "service_url"
-DefaultZone = "zone"
-DefaultHTTPProxy = "http_proxy"
+ServiceURL = "service_url"
+Zone = "zone"
+HTTPProxy = "http_proxy"
 [Host.GCP]
-DefaultMachineType = "machine_type"
-DefaultMinCPUPlatform = "cpu_platform"
+MachineType = "machine_type"
+MinCPUPlatform = "cpu_platform"
 `
 	invalidConfig = "foo_bar_baz = \"unknown field\""
 )

--- a/pkg/cli/host.go
+++ b/pkg/cli/host.go
@@ -51,9 +51,9 @@ func newHostCommand(opts *subCommandOpts) *cobra.Command {
 		},
 	}
 	create.Flags().StringVar(&createFlags.MachineType, gcpMachineTypeFlag,
-		opts.Config.Host.GCP.DefaultMachineType, "Indicates the machine type")
+		opts.InitialConfig.Host.GCP.MachineType, "Indicates the machine type")
 	create.Flags().StringVar(&createFlags.MinCPUPlatform, gcpMinCPUPlatformFlag,
-		opts.Config.Host.GCP.DefaultMinCPUPlatform,
+		opts.InitialConfig.Host.GCP.MinCPUPlatform,
 		"Specifies a minimum CPU platform for the VM instance")
 	list := &cobra.Command{
 		Use:   "list",


### PR DESCRIPTION
- The `Default` prefix is not needed and it's getting carried on to new parameters for consistency purposes.