### PR TITLE
[cli] Fixes error.

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -88,6 +88,9 @@ func (fakeService) ConnectWebRTC(host, device string, observer wclient.Observer)
 }
 
 func (fakeService) CreateCVD(host string, req *hoapi.CreateCVDRequest) (*hoapi.CVD, error) {
+	if host == "" {
+		panic("empty host")
+	}
 	return &hoapi.CVD{Name: "cvd-1"}, nil
 }
 

--- a/pkg/cli/cvd.go
+++ b/pkg/cli/cvd.go
@@ -128,27 +128,24 @@ func createCVD(c *cobra.Command, flags *CreateCVDFlags, opts *subCommandOpts) er
 		return fmt.Errorf("Failed to build service instance: %w", err)
 
 	}
-	host := flags.CreateCVDOpts.Host
-	if host == "" {
+	createOpts := *flags.CreateCVDOpts
+	if createOpts.Host == "" {
 		ins, err := createHost(service, *flags.CreateHostOpts)
 		if err != nil {
 			return fmt.Errorf("Failed to create host: %w", err)
 		}
-
-		host = ins.Name
+		createOpts.Host = ins.Name
 	}
-	createOpts := *flags.CreateCVDOpts
-	createOpts.Host = host
 	creator := &cvdCreator{
 		Service: service,
-		Opts:    *flags.CreateCVDOpts,
+		Opts:    createOpts,
 	}
 	cvd, err := creator.Create()
 	if err != nil {
 		return fmt.Errorf("Failed to create cvd: %w", err)
 	}
 	rootEndpoint := buildServiceRootEndpoint(flags.ServiceURL, flags.Zone)
-	printCVDs(c.OutOrStdout(), rootEndpoint, host, []*hoapi.CVD{cvd})
+	printCVDs(c.OutOrStdout(), rootEndpoint, createOpts.Host, []*hoapi.CVD{cvd})
 	return nil
 }
 


### PR DESCRIPTION
- Passes the value of the newly created instance rather than the empty value from the command line.