### PR TITLE
Make webrtc library log to the log files

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -93,7 +93,7 @@ func (fakeService) GetInfraConfig(host string) (*apiv1.InfraConfig, error) {
 	return nil, nil
 }
 
-func (fakeService) ConnectWebRTC(host, device string, observer wclient.Observer) (*wclient.Connection, error) {
+func (fakeService) ConnectWebRTC(host, device string, observer wclient.Observer, logger io.Writer) (*wclient.Connection, error) {
 	return nil, nil
 }
 

--- a/pkg/cli/conn.go
+++ b/pkg/cli/conn.go
@@ -399,7 +399,7 @@ func NewConnController(controlDir string, service client.Service, cvd CVD) (*Con
 		logger:       logger,
 	}
 
-	conn, err := service.ConnectWebRTC(cvd.Host, cvd.Name, tc)
+	conn, err := service.ConnectWebRTC(cvd.Host, cvd.Name, tc, logger.Writer())
 	if err != nil {
 		return nil, fmt.Errorf("Failed to connect to %q: %w", cvd.Name, err)
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -94,7 +94,7 @@ type Service interface {
 
 	GetInfraConfig(host string) (*apiv1.InfraConfig, error)
 
-	ConnectWebRTC(host, device string, observer wclient.Observer) (*wclient.Connection, error)
+	ConnectWebRTC(host, device string, observer wclient.Observer, logger io.Writer) (*wclient.Connection, error)
 
 	CreateCVD(host string, req *hoapi.CreateCVDRequest) (*hoapi.CVD, error)
 
@@ -178,7 +178,7 @@ func (c *serviceImpl) GetInfraConfig(host string) (*apiv1.InfraConfig, error) {
 	return &res, nil
 }
 
-func (c *serviceImpl) ConnectWebRTC(host, device string, observer wclient.Observer) (*wclient.Connection, error) {
+func (c *serviceImpl) ConnectWebRTC(host, device string, observer wclient.Observer, logger io.Writer) (*wclient.Connection, error) {
 	polledConn, err := c.createPolledConnection(host, device)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create polled connection: %w", err)
@@ -188,7 +188,7 @@ func (c *serviceImpl) ConnectWebRTC(host, device string, observer wclient.Observ
 		return nil, fmt.Errorf("Failed to obtain infra config: %w", err)
 	}
 	signaling := c.initHandling(host, polledConn.ConnId, infraConfig.IceServers)
-	conn, err := wclient.NewConnection(&signaling, observer)
+	conn, err := wclient.NewConnectionWithLogger(&signaling, observer, logger)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to connect to device over webrtc: %w", err)
 	}


### PR DESCRIPTION
instead of stdout, which breaks communication between connection agent and create command.