### PR TITLE
[orchestrator] Supports `acloud pull`

### DIFF
--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -46,6 +46,8 @@ const (
 type GCPIMConfig struct {
 	ProjectID string
 	HostImage string
+	// If true, instances created should be compatible with `acloud CLI`.
+	AcloudCompatible bool
 }
 
 type AMConfig struct {


### PR DESCRIPTION
Allows `acloud pull` command to work with hosts created with the cloud orchestrator.