### PR TITLE
Use image families for declaring host image source.

### DIFF
--- a/conf.toml
+++ b/conf.toml
@@ -23,7 +23,7 @@ AllowSelfSignedHostSSLCertificate = true
 
 [InstanceManager.GCP]
 ProjectId = ""
-HostImage = ""
+HostImageFamily = ""
 HostOrchestratorPort = 1443
 
 [InstanceManager.UNIX]

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -50,7 +50,7 @@ const (
 
 type GCPIMConfig struct {
 	ProjectID            string
-	HostImage            string
+	HostImageFamily      string
 	HostOrchestratorPort int
 	// If true, instances created should be compatible with `acloud CLI`.
 	AcloudCompatible bool

--- a/pkg/app/net/gcp/instancemanager.go
+++ b/pkg/app/net/gcp/instancemanager.go
@@ -90,7 +90,7 @@ func (m *InstanceManager) CreateHost(zone string, req *apiv1.CreateHostRequest, 
 		Disks: []*compute.AttachedDisk{
 			{
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: m.Config.GCP.HostImage,
+					SourceImage: m.Config.GCP.HostImageFamily,
 				},
 				Boot: true,
 			},

--- a/pkg/app/net/gcp/instancemanager_test.go
+++ b/pkg/app/net/gcp/instancemanager_test.go
@@ -38,8 +38,8 @@ import (
 
 var testConfig = app.IMConfig{
 	GCP: &app.GCPIMConfig{
-		ProjectID: "google.com:test-project",
-		HostImage: "projects/test-project-releases/global/images/img-001",
+		ProjectID:       "google.com:test-project",
+		HostImageFamily: "projects/test-project-releases/global/images/family/foo",
 	},
 }
 
@@ -150,7 +150,7 @@ func TestCreateHostRequestBody(t *testing.T) {
     {
       "boot": true,
       "initializeParams": {
-        "sourceImage": "projects/test-project-releases/global/images/img-001"
+        "sourceImage": "projects/test-project-releases/global/images/family/foo"
       }
     }
   ],
@@ -191,7 +191,7 @@ func TestCreateHostAcloudCompatible(t *testing.T) {
 		Config: app.IMConfig{
 			GCP: &app.GCPIMConfig{
 				ProjectID:        "google.com:test-project",
-				HostImage:        "projects/test-project-releases/global/images/img-001",
+				HostImageFamily:  "projects/test-project-releases/global/images/family/foo",
 				AcloudCompatible: true,
 			},
 		},


### PR DESCRIPTION
- Using the image family will reference the latest image added to the family.