### PR TITLE
Show error in case cvd-host_package.tar.gz does not exist.

### DIFF
--- a/pkg/cli/cvd_test.go
+++ b/pkg/cli/cvd_test.go
@@ -103,7 +103,6 @@ func TestListLocalImageRequiredFiles(t *testing.T) {
 		"/out/host/linux-x86/foo",
 		"/out/host/linux-x86/bar",
 		"/out/host/linux-x86/baz",
-		"/product/vsoc_x86_64/cvd-host_package.tar.gz",
 	}
 	if diff := cmp.Diff(expected, got); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)


### PR DESCRIPTION
- The cvd host package tarball is required when creating local image instances.