### PR TITLE
Add missing APIs to retrieve cloud orchestration info for Page 0

### DIFF
--- a/api/v1/instancemanager.go
+++ b/api/v1/instancemanager.go
@@ -5,6 +5,10 @@ type CreateHostRequest struct {
 	HostInstance *HostInstance `json:"host_instance"`
 }
 
+type Zone struct {
+	Name string `json:"name"`
+}
+
 type HostInstance struct {
 	// [Output Only] Instance name.
 	Name string `json:"name,omitempty"`
@@ -41,6 +45,10 @@ type OperationResult struct {
 	// method is standard: `Get`/`Create`/`Update`, the response should be the relevant resource
 	// encoded in JSON format.
 	Response string `json:"response,omitempty"`
+}
+
+type ListZonesResponse struct {
+	Items []*Zone `json:"items"`
 }
 
 type ListHostsResponse struct {

--- a/api/v1/instancemanager.go
+++ b/api/v1/instancemanager.go
@@ -60,3 +60,8 @@ type ListHostsResponse struct {
 	// paging through out all the results.
 	NextPageToken string `json:"nextPageToken,omitempty"`
 }
+
+// To be seperated in to new file if the config needs to contain intormation other than instance manager
+type Config struct {
+	InstanceManagerType string `json:"instance_manager_type"`
+}

--- a/cmd/cloud_orchestrator/main.go
+++ b/cmd/cloud_orchestrator/main.go
@@ -168,7 +168,7 @@ func main() {
 	encryptionService := LoadEncryptionService(config)
 	dbService := LoadDatabaseService(config)
 	controller := app.NewApp(instanceManager, accountManager, oauth2Helper,
-		encryptionService, dbService, config.WebStaticFilesPath, config.CORSAllowedOrigins, config.WebRTC)
+		encryptionService, dbService, config.WebStaticFilesPath, config.CORSAllowedOrigins, config.WebRTC, config)
 
 	iface := ChooseNetworkInterface(config)
 	port := ServerPort()

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -92,6 +92,7 @@ func (c *App) Handler() http.Handler {
 	router := mux.NewRouter()
 
 	// Instance Manager Routes
+	router.Handle("/v1/zones", c.Authenticate(c.listZones)).Methods("GET")
 	router.Handle("/v1/zones/{zone}/hosts", c.Authenticate(c.createHost)).Methods("POST")
 	router.Handle("/v1/zones/{zone}/hosts", c.Authenticate(c.listHosts)).Methods("GET")
 	// Waits for the specified operation to be DONE or for the request to approach the specified deadline,
@@ -182,6 +183,15 @@ func (a *App) injectBuildAPICredsIntoRequest(r *http.Request, user accounts.User
 			"The user must authorize the system to access the Build API on their behalf", nil)
 	}
 	r.Header.Set(headerNameHOBuildAPICreds, tk.AccessToken)
+	return nil
+}
+
+func (c *App) listZones(w http.ResponseWriter, r *http.Request, user accounts.User) error {
+	res, err := c.instanceManager.ListZones()
+	if err != nil {
+		return err
+	}
+	replyJSON(w, res, http.StatusOK)
 	return nil
 }
 

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -110,7 +110,7 @@ func (hc *testHostClient) GetReverseProxy() *httputil.ReverseProxy {
 }
 
 func TestListZonesSucceeds(t *testing.T) {
-	controller := NewApp(&testInstanceManager{}, &testAccountManager{}, nil, nil, nil, "", nil, config.WebRTCConfig{})
+	controller := NewApp(&testInstanceManager{}, &testAccountManager{}, nil, nil, nil, "", nil, config.WebRTCConfig{}, &config.Config{})
 	ts := httptest.NewServer(controller.Handler())
 	defer ts.Close()
 
@@ -123,7 +123,7 @@ func TestListZonesSucceeds(t *testing.T) {
 }
 
 func TestCreateHostSucceeds(t *testing.T) {
-	controller := NewApp(&testInstanceManager{}, &testAccountManager{}, nil, nil, nil, "", nil, config.WebRTCConfig{})
+	controller := NewApp(&testInstanceManager{}, &testAccountManager{}, nil, nil, nil, "", nil, config.WebRTCConfig{}, &config.Config{})
 	ts := httptest.NewServer(controller.Handler())
 	defer ts.Close()
 
@@ -137,7 +137,7 @@ func TestCreateHostSucceeds(t *testing.T) {
 }
 
 func TestWaitOperatioSucceeds(t *testing.T) {
-	controller := NewApp(&testInstanceManager{}, &testAccountManager{}, nil, nil, nil, "", nil, config.WebRTCConfig{})
+	controller := NewApp(&testInstanceManager{}, &testAccountManager{}, nil, nil, nil, "", nil, config.WebRTCConfig{}, &config.Config{})
 	ts := httptest.NewServer(controller.Handler())
 	defer ts.Close()
 
@@ -208,7 +208,7 @@ func TestDeleteHostIsHandled(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	controller := NewApp(&testInstanceManager{}, &testAccountManager{}, nil, nil, nil, "", nil, config.WebRTCConfig{})
+	controller := NewApp(&testInstanceManager{}, &testAccountManager{}, nil, nil, nil, "", nil, config.WebRTCConfig{}, &config.Config{})
 
 	makeRequest(rr, req, controller)
 
@@ -250,7 +250,7 @@ func TestHostForwarderRequest(t *testing.T) {
 		hostClientFactory: func(_, _ string) instances.HostClient {
 			return &testHostClient{hostURL}
 		},
-	}, &testAccountManager{}, nil, nil, nil, "", nil, config.WebRTCConfig{})
+	}, &testAccountManager{}, nil, nil, nil, "", nil, config.WebRTCConfig{}, &config.Config{})
 
 	tests := []struct {
 		method  string
@@ -356,7 +356,7 @@ func TestHostForwarderInjectCredentialsUsingHTTPHeader(t *testing.T) {
 		hostClientFactory: func(_, _ string) instances.HostClient {
 			return &testHostClient{hostURL}
 		},
-	}, &testAccountManager{}, nil, encryption.NewFakeEncryptionService(), dbs, "", nil, config.WebRTCConfig{})
+	}, &testAccountManager{}, nil, encryption.NewFakeEncryptionService(), dbs, "", nil, config.WebRTCConfig{}, &config.Config{})
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest(http.MethodGet, reqURL, nil)
 	req.Header.Set(headerNameCOInjectBuildAPICreds, "")
@@ -412,7 +412,7 @@ func TestHostForwarderDoesNotInjectCredentials(t *testing.T) {
 		hostClientFactory: func(_, _ string) instances.HostClient {
 			return &testHostClient{hostURL}
 		},
-	}, &testAccountManager{}, nil, nil, dbs, "", nil, config.WebRTCConfig{})
+	}, &testAccountManager{}, nil, nil, dbs, "", nil, config.WebRTCConfig{}, &config.Config{})
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest(http.MethodPost, reqURL, bytes.NewBuffer(msg))
@@ -438,7 +438,7 @@ func TestBadCSRFTokensInRescindAuth(t *testing.T) {
 				Key:         sessionId,
 				OAuth2State: "righttoken",
 			})
-			controller := NewApp(&testInstanceManager{}, &testAccountManager{}, nil, nil, dbs, "", nil, config.WebRTCConfig{})
+			controller := NewApp(&testInstanceManager{}, &testAccountManager{}, nil, nil, dbs, "", nil, config.WebRTCConfig{}, &config.Config{})
 			ts := httptest.NewServer(controller.Handler())
 			defer ts.Close()
 
@@ -471,6 +471,20 @@ func TestBadCSRFTokensInRescindAuth(t *testing.T) {
 		})
 	}
 
+}
+
+func TestGetConfigSucceeds(t *testing.T) {
+	controller := NewApp(&testInstanceManager{}, &testAccountManager{}, nil, nil, nil, "", nil, config.WebRTCConfig{}, &config.Config{})
+	ts := httptest.NewServer(controller.Handler())
+	defer ts.Close()
+
+	res, _ := http.Get(ts.URL + "/v1/config")
+
+	expected := http.StatusOK
+
+	if res.StatusCode != expected {
+		t.Errorf("unexpected status code <<%d>>, want: %d", res.StatusCode, expected)
+	}
 }
 
 func assertIsAppError(t *testing.T, err error) {

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -69,6 +69,10 @@ func (m *testInstanceManager) GetHostURL(zone string, host string) (*url.URL, er
 	return url.Parse("http://127.0.0.1:8080")
 }
 
+func (m *testInstanceManager) ListZones() (*apiv1.ListZonesResponse, error) {
+	return &apiv1.ListZonesResponse{}, nil
+}
+
 func (m *testInstanceManager) CreateHost(_ string, _ *apiv1.CreateHostRequest, _ accounts.User) (*apiv1.Operation, error) {
 	return &apiv1.Operation{}, nil
 }
@@ -103,6 +107,19 @@ func (hc *testHostClient) Post(path, query string, bodyJSON any, res *instances.
 
 func (hc *testHostClient) GetReverseProxy() *httputil.ReverseProxy {
 	return httputil.NewSingleHostReverseProxy(hc.url)
+}
+
+func TestListZonesSucceeds(t *testing.T) {
+	controller := NewApp(&testInstanceManager{}, &testAccountManager{}, nil, nil, nil, "", nil, config.WebRTCConfig{})
+	ts := httptest.NewServer(controller.Handler())
+	defer ts.Close()
+
+	res, _ := http.Get(ts.URL + "/v1/zones")
+
+	expected := http.StatusOK
+	if res.StatusCode != expected {
+		t.Errorf("unexpected status code <<%d>>, want: %d", res.StatusCode, expected)
+	}
 }
 
 func TestCreateHostSucceeds(t *testing.T) {

--- a/pkg/app/instances/gce.go
+++ b/pkg/app/instances/gce.go
@@ -69,8 +69,8 @@ func (m *GCEInstanceManager) ListZones() (*apiv1.ListZonesResponse, error) {
 	}
 
 	var items []*apiv1.Zone
-	for _, i := range res.Items {
-		hi, err := BuildZone(i)
+	for _, item := range res.Items {
+		hi, err := BuildZone(item)
 		if err != nil {
 			return nil, err
 		}
@@ -184,8 +184,8 @@ func (m *GCEInstanceManager) ListHosts(zone string, user accounts.User, req *Lis
 		return nil, toAppError(err)
 	}
 	var items []*apiv1.HostInstance
-	for _, i := range res.Items {
-		hi, err := BuildHostInstance(i)
+	for _, item := range res.Items {
+		hi, err := BuildHostInstance(item)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/app/instances/gce.go
+++ b/pkg/app/instances/gce.go
@@ -70,11 +70,7 @@ func (m *GCEInstanceManager) ListZones() (*apiv1.ListZonesResponse, error) {
 
 	var items []*apiv1.Zone
 	for _, item := range res.Items {
-		hi, err := BuildZone(item)
-		if err != nil {
-			return nil, err
-		}
-		items = append(items, hi)
+		items = append(items, &apiv1.Zone{Name: item.Name})
 	}
 	return &apiv1.ListZonesResponse{
 		Items: items,
@@ -261,12 +257,6 @@ func validateRequest(r *apiv1.CreateHostRequest) error {
 
 func buildDefaultNetworkName(projectID string) string {
 	return fmt.Sprintf("projects/%s/global/networks/default", projectID)
-}
-
-func BuildZone(in *compute.Zone) (*apiv1.Zone, error) {
-	return &apiv1.Zone{
-		Name: in.Name,
-	}, nil
 }
 
 func BuildHostInstance(in *compute.Instance) (*apiv1.HostInstance, error) {

--- a/pkg/app/instances/instances.go
+++ b/pkg/app/instances/instances.go
@@ -22,6 +22,8 @@ import (
 )
 
 type Manager interface {
+	// List zones
+	ListZones() (*apiv1.ListZonesResponse, error)
 	// Creates a host instance.
 	CreateHost(zone string, req *apiv1.CreateHostRequest, user accounts.User) (*apiv1.Operation, error)
 	// List hosts

--- a/pkg/app/instances/local.go
+++ b/pkg/app/instances/local.go
@@ -53,6 +53,14 @@ func (m *LocalInstanceManager) GetHostURL(zone string, host string) (*url.URL, e
 	return url.Parse(fmt.Sprintf("%s://%s:%d", m.config.HostOrchestratorProtocol, addr, m.config.UNIX.HostOrchestratorPort))
 }
 
+func (m *LocalInstanceManager) ListZones() (*apiv1.ListZonesResponse, error) {
+	return &apiv1.ListZonesResponse{
+		Items: []*apiv1.Zone{{
+			Name: "local",
+		}},
+	}, nil
+}
+
 func (m *LocalInstanceManager) CreateHost(_ string, _ *apiv1.CreateHostRequest, _ accounts.User) (*apiv1.Operation, error) {
 	return &apiv1.Operation{
 		Name: "Create Host",


### PR DESCRIPTION
- [x] `GET /info` to check validity of the cloud orchestrator & give additional information on the cloud orchestrator
- [x] `GET /v1/zones` to list zones available for GCP instance manager

** Update **
- `GET /v1/info` became `GET /v1/config` to retreive configuration of the cloud orchestrator
- 'Runtime' concept lies on Page 0 UI and not will be revealed on cloud orchestrator side

