### PR TITLE
Add additional settings to handle CORS

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -82,6 +82,9 @@ func (c *App) AddCorsHeaderIfNeeded(w http.ResponseWriter, r *http.Request) {
 	for _, allowed := range c.corsAllowedOrigins {
 		if origin == allowed {
 			w.Header().Add("Access-Control-Allow-Origin", origin)
+			w.Header().Add("Access-Control-Allow-Methods", "GET, POST, OPTIONS, PUT, DELETE")
+			w.Header().Add("Access-Control-Allow-Headers", "Content-Type")
+			w.Header().Add("Access-Control-Allow-Credentials", "true")
 			break
 		}
 	}

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -46,6 +46,7 @@ import (
 
 const (
 	sessionIdCookie = "sessionid"
+	allowedMethods  = "GET, POST, PUT, DELETE, OPTIONS, HEAD"
 )
 
 // The controller implements the web API of the cloud orchestrator. It parses
@@ -82,7 +83,7 @@ func (c *App) AddCorsHeaderIfNeeded(w http.ResponseWriter, r *http.Request) {
 	for _, allowed := range c.corsAllowedOrigins {
 		if origin == allowed {
 			w.Header().Add("Access-Control-Allow-Origin", origin)
-			w.Header().Add("Access-Control-Allow-Methods", "GET, POST, OPTIONS, PUT, DELETE")
+			w.Header().Add("Access-Control-Allow-Methods", allowedMethods)
 			w.Header().Add("Access-Control-Allow-Headers", "Content-Type")
 			w.Header().Add("Access-Control-Allow-Credentials", "true")
 			break
@@ -125,6 +126,13 @@ func (c *App) Handler() http.Handler {
 	rootRouter.PathPrefix("/").Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c.AddCorsHeaderIfNeeded(w, r)
 		router.ServeHTTP(w, r)
+		if r.Method == "OPTIONS" {
+			w.Header().Add("Allow", allowedMethods)
+			w.WriteHeader(http.StatusNoContent)
+			return
+		} else {
+			router.ServeHTTP(w, r)
+		}
 	}))
 
 	return rootRouter

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -125,7 +125,6 @@ func (c *App) Handler() http.Handler {
 	rootRouter := mux.NewRouter()
 	rootRouter.PathPrefix("/").Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c.AddCorsHeaderIfNeeded(w, r)
-		router.ServeHTTP(w, r)
 		if r.Method == "OPTIONS" {
 			w.Header().Add("Allow", allowedMethods)
 			w.WriteHeader(http.StatusNoContent)

--- a/web/page0/src/app/app.module.ts
+++ b/web/page0/src/app/app.module.ts
@@ -35,6 +35,7 @@ import {MatProgressBarModule} from '@angular/material/progress-bar';
 import {MatSnackBarModule} from '@angular/material/snack-bar';
 import {DeviceFormComponent} from './device-form/device-form.component';
 import {SafeUrlPipe} from './safe-url.pipe';
+import {httpInterceptorProviders} from 'src/http-interceptors';
 
 @NgModule({
   declarations: [
@@ -81,7 +82,7 @@ import {SafeUrlPipe} from './safe-url.pipe';
       {path: 'register-runtime', component: RegisterRuntimeViewComponent},
     ]),
   ],
-  providers: [],
+  providers: [httpInterceptorProviders],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/web/page0/src/http-interceptors/cors.interceptor.spec.ts
+++ b/web/page0/src/http-interceptors/cors.interceptor.spec.ts
@@ -1,0 +1,16 @@
+import {TestBed} from '@angular/core/testing';
+
+import {CorsInterceptor} from './cors.interceptor';
+
+describe('CorsInterceptor', () => {
+  beforeEach(() =>
+    TestBed.configureTestingModule({
+      providers: [CorsInterceptor],
+    })
+  );
+
+  it('should be created', () => {
+    const interceptor: CorsInterceptor = TestBed.inject(CorsInterceptor);
+    expect(interceptor).toBeTruthy();
+  });
+});

--- a/web/page0/src/http-interceptors/cors.interceptor.ts
+++ b/web/page0/src/http-interceptors/cors.interceptor.ts
@@ -1,0 +1,24 @@
+import {Injectable} from '@angular/core';
+import {
+  HttpRequest,
+  HttpHandler,
+  HttpEvent,
+  HttpInterceptor,
+} from '@angular/common/http';
+import {Observable} from 'rxjs';
+
+@Injectable()
+export class CorsInterceptor implements HttpInterceptor {
+  constructor() {}
+
+  intercept(
+    req: HttpRequest<unknown>,
+    next: HttpHandler
+  ): Observable<HttpEvent<unknown>> {
+    return next.handle(
+      req.clone({
+        withCredentials: true,
+      })
+    );
+  }
+}

--- a/web/page0/src/http-interceptors/index.ts
+++ b/web/page0/src/http-interceptors/index.ts
@@ -1,0 +1,6 @@
+import {HTTP_INTERCEPTORS} from '@angular/common/http';
+import {CorsInterceptor} from './cors.interceptor';
+
+export const httpInterceptorProviders = [
+  {provide: HTTP_INTERCEPTORS, useClass: CorsInterceptor, multi: true},
+];

--- a/web/page0/src/server.py
+++ b/web/page0/src/server.py
@@ -6,33 +6,39 @@ import requests
 
 import test_apis
 
-EXCLUDED_HEADERS = {'content-encoding', 'content-length', 'transfer-encoding',
-                    'connection'}
+EXCLUDED_HEADERS = {
+    "content-encoding",
+    "content-length",
+    "transfer-encoding",
+    "connection",
+}
 
 _PORT = flags.DEFINE_integer(
-    'port',
+    "port",
     default=8071,
-    help='default port',
+    help="default port",
 )
 
 _ANGULAR_URL = flags.DEFINE_string(
-    'angular_url',
-    default='http://localhost:4200/',
-    help='default angular url',
+    "angular_url",
+    default="http://localhost:4200/",
+    help="default angular url",
 )
 
-app = flask.Flask(
-    __name__
-)
+app = flask.Flask(__name__)
 
 app.register_blueprint(test_apis.apis)
+
 
 @app.route("/")
 def index():
     response = requests.get(_ANGULAR_URL.value)
 
-    headers = [(key, value) for (key, value) in response.raw.headers.items()
-                 if key.lower() not in EXCLUDED_HEADERS]
+    headers = [
+        (key, value)
+        for (key, value) in response.raw.headers.items()
+        if key.lower() not in EXCLUDED_HEADERS
+    ]
 
     headers.append(("Access-Control-Allow-Origin", "*"))
 
@@ -43,24 +49,31 @@ def index():
 def proxy(path):
     response = requests.get(f"{_ANGULAR_URL.value}{path}")
 
-    headers = [(key, value) for (key, value) in response.raw.headers.items()
-                 if key.lower() not in EXCLUDED_HEADERS]
+    headers = [
+        (key, value)
+        for (key, value) in response.raw.headers.items()
+        if key.lower() not in EXCLUDED_HEADERS
+    ]
 
     headers.append(("Access-Control-Allow-Origin", "*"))
 
     return flask.Response(response.content, response.status_code, headers)
 
+
 @app.after_request
 def cors(response):
     header = response.headers
-    header['Access-Control-Allow-Origin'] = '*'
-    header['Access-Control-Allow-Methods'] =  "GET, POST, OPTIONS, PUT, DELETE"
-    header['Access-Control-Allow-Headers'] =  "Content-Type"
+    header["Access-Control-Allow-Origin"] = "http://localhost:39183"
+    header["Access-Control-Allow-Methods"] = "GET, POST, OPTIONS, PUT, DELETE"
+    header["Access-Control-Allow-Headers"] = "Content-Type"
+    header["Access-Control-Allow-Credentials"] = "true"
 
     return response
 
-def main(argv):
-  app.run(host='::', port=_PORT.value, debug=True)
 
-if __name__ == '__main__':
-  absl_app.run(main)
+def main(argv):
+    app.run(host="::", port=_PORT.value, debug=True)
+
+
+if __name__ == "__main__":
+    absl_app.run(main)


### PR DESCRIPTION
- `CorsInterceptor` in frontend & `Access-Control-Allow-Credentials` in cloud orchestrator allows HTTP requests to carry cookies
- Explicitly added allowed methods 
- Handle preflight request as specified from [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)