### PR TITLE
Page0 Handler for failed authentication request

### DIFF
--- a/web/page0/src/http_interceptors/auth.interceptor.ts
+++ b/web/page0/src/http_interceptors/auth.interceptor.ts
@@ -1,0 +1,38 @@
+import {Injectable} from '@angular/core';
+import {
+  HttpRequest,
+  HttpHandler,
+  HttpEvent,
+  HttpInterceptor,
+  HttpErrorResponse,
+} from '@angular/common/http';
+import {Observable} from 'rxjs';
+import {catchError} from 'rxjs/operators';
+import {MatSnackBar} from '@angular/material/snack-bar';
+
+const handleAuthError = (error: HttpErrorResponse, snackBar: MatSnackBar) => {
+  console.error(error);
+  snackBar.open('Request failed: check your credentials');
+};
+
+@Injectable()
+export class AuthInterceptor implements HttpInterceptor {
+  constructor(private snackBar: MatSnackBar) {}
+
+  intercept(
+    request: HttpRequest<unknown>,
+    next: HttpHandler
+  ): Observable<HttpEvent<unknown>> {
+    return next.handle(request).pipe(
+      catchError((error: HttpErrorResponse) => {
+        // If credentails got expired, OPTIONS request fails before the actual request
+        // Thus, error status becomes 0 for CORS failure
+        if (error.status === 0) {
+          handleAuthError(error, this.snackBar);
+        }
+
+        throw error;
+      })
+    );
+  }
+}

--- a/web/page0/src/http_interceptors/auth.interceptor.ts
+++ b/web/page0/src/http_interceptors/auth.interceptor.ts
@@ -11,8 +11,9 @@ import {catchError} from 'rxjs/operators';
 import {MatSnackBar} from '@angular/material/snack-bar';
 
 const handleAuthError = (error: HttpErrorResponse, snackBar: MatSnackBar) => {
-  console.error(error);
-  snackBar.open('Request failed: check your credentials');
+  snackBar.open(
+    `Request failed: check your credentials (error message: ${error.message})`
+  );
 };
 
 @Injectable()

--- a/web/page0/src/http_interceptors/index.ts
+++ b/web/page0/src/http_interceptors/index.ts
@@ -1,6 +1,8 @@
 import {HTTP_INTERCEPTORS} from '@angular/common/http';
+import {AuthInterceptor} from './auth.interceptor';
 import {CorsInterceptor} from './cors.interceptor';
 
 export const httpInterceptorProviders = [
   {provide: HTTP_INTERCEPTORS, useClass: CorsInterceptor, multi: true},
+  {provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true},
 ];


### PR DESCRIPTION
- ~~Retry `RETRY_COUNT` times at intervals of `RETRY_INTERVAL_SEC` seconds as specified on `src/app/settings.ts`~~
- ~~Open new tab with the failed request url, as cloud orchestrators ought to redirect the request to the url for authentication~~

[ Update ]
- Simply shows snackbar if auth error happens
- Detailed error handling logic (e.g. redirect to login url) can be handled from function `handleAuthError `




