### PR TITLE
Display hierarchical view when listing cvds.

### DIFF
--- a/pkg/cli/cvd_test.go
+++ b/pkg/cli/cvd_test.go
@@ -19,35 +19,8 @@ import (
 	"path"
 	"testing"
 
-	hoapi "github.com/google/android-cuttlefish/frontend/src/liboperator/api/v1"
 	"github.com/google/go-cmp/cmp"
 )
-
-func TestCVDOutput(t *testing.T) {
-	output := NewRemoteCVD("http://foo.com", "bar", &hoapi.CVD{
-		Name:     "cvd-1",
-		Status:   "Running",
-		Displays: []string{"720 x 1280 ( 320 )"},
-	})
-	output.ConnStatus = &ConnStatus{
-		ADB: ForwarderState{
-			Port: 12345,
-		},
-	}
-
-	got := ToPrintableStr(output)
-
-	expected := `cvd-1 (bar)
-  Status: Running
-  ADB: 127.0.0.1:12345
-  Displays: [720 x 1280 ( 320 )]
-  WebRTCStream: http://foo.com/hosts/bar/devices/cvd-1/files/client.html
-  Logs: http://foo.com/hosts/bar/cvds/cvd-1/logs/`
-
-	if diff := cmp.Diff(expected, got); diff != "" {
-		t.Errorf("mismatch (-want +got):\n%s", diff)
-	}
-}
 
 func TestGetAndroidEnvVarValuesMissingVariable(t *testing.T) {
 	// testing.T doesn't have an equivalent Unsetenv function.

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -761,8 +761,8 @@ func BuildRootEndpoint(serviceURL, version, zone string) string {
 	return result
 }
 
-func BuildWebRTCStreamURL(rootEndpoint, host, cvd string) string {
-	return fmt.Sprintf("%s/hosts/%s/devices/%s/files/client.html", rootEndpoint, host, cvd)
+func BuilHostIndexURL(rootEndpoint, host string) string {
+	return fmt.Sprintf("%s/hosts/%s/", rootEndpoint, host)
 }
 
 func BuildCVDLogsURL(rootEndpoint, host, cvd string) string {


### PR DESCRIPTION
- Remove device specific WebRTCStream url and print host Web UI only.

Before:
```
1 (cf-7ed82aa8-cfcd-428e-9704-082e2338be87)
  Status: Running
  ADB: not connected
2 (cf-7ed82aa8-cfcd-428e-9704-082e2338be87)
  Status: Running
  ADB: not connected
```

After:
```
cf-7ed82aa8-cfcd-428e-9704-082e2338be87 (http://...)
  1
  Status: Running
  ADB: not connected

  2
  Status: Running
  ADB: not connected
```