### PR TITLE
Print non-critical errors as warnings

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -607,13 +607,13 @@ func disconnectDevicesByHost(host string, opts *subCommandOpts) error {
 	if err != nil {
 		return fmt.Errorf("Failed to list connections: %w", err)
 	}
+	var merr error
 	for cvd, status := range statuses {
 		if err := DisconnectCVD(controlDir, cvd, status); err != nil {
-			// Warn only, the host can still be deleted
-			return fmt.Errorf("Errors closing connection to %s: %w", cvd.WebRTCDeviceID, err)
+			merr = multierror.Append(merr, fmt.Errorf("Failed to disconnect from %s: %w", cvd.WebRTCDeviceID, err))
 		}
 	}
-	return nil
+	return merr
 }
 
 const (

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -594,7 +594,8 @@ func runDeleteHostsCommand(c *cobra.Command, args []string, flags *CVDRemoteFlag
 	// Close connections first to avoid spurious error messages later.
 	for _, host := range hosts {
 		if err := disconnectDevicesByHost(host, opts); err != nil {
-			c.PrintErrf("Error disconecting devices for host %s: %v\n", host, err)
+			// Warn only, the host can still be deleted
+			c.PrintErrf("Warning: Failed to disconnect devices for host %s: %v\n", host, err)
 		}
 	}
 	return service.DeleteHosts(hosts)
@@ -604,8 +605,7 @@ func disconnectDevicesByHost(host string, opts *subCommandOpts) error {
 	controlDir := opts.InitialConfig.ConnectionControlDirExpanded()
 	statuses, err := listCVDConnectionsByHost(controlDir, host)
 	if err != nil {
-		// Warn only, the host can still be deleted
-		return fmt.Errorf("Errors listing connections: %w", err)
+		return fmt.Errorf("Failed to list connections: %w", err)
 	}
 	for cvd, status := range statuses {
 		if err := DisconnectCVD(controlDir, cvd, status); err != nil {


### PR DESCRIPTION
When deleting hosts