### PR TITLE
Prevent infinite loading when runtimes length is 0

### DIFF
--- a/web/page0/src/app/refresh.service.ts
+++ b/web/page0/src/app/refresh.service.ts
@@ -57,14 +57,14 @@ export class RefreshService {
       this.prevSubscription.unsubscribe();
     }
 
+    this.store.dispatch({
+      type: ActionType.RefreshStart,
+    });
+
     const subscription = forkJoin(
       settings.map(({url, alias}) => this.refreshRuntime(url, alias))
     )
-      .pipe(tap(() => {
-        this.store.dispatch({
-          type: ActionType.RefreshStart,
-        });
-      }), defaultIfEmpty([]))
+      .pipe(defaultIfEmpty([]))
       .subscribe({
         complete: () => {
           this.store.dispatch({type: ActionType.RefreshComplete});

--- a/web/page0/src/app/refresh.service.ts
+++ b/web/page0/src/app/refresh.service.ts
@@ -60,16 +60,16 @@ export class RefreshService {
     const subscription = forkJoin(
       settings.map(({url, alias}) => this.refreshRuntime(url, alias))
     )
-      .pipe(defaultIfEmpty([]))
+      .pipe(tap(() => {
+        this.store.dispatch({
+          type: ActionType.RefreshStart,
+        });
+      }), defaultIfEmpty([]))
       .subscribe({
         complete: () => {
           this.store.dispatch({type: ActionType.RefreshComplete});
         },
       });
-
-    this.store.dispatch({
-      type: ActionType.RefreshStart,
-    });
 
     this.prevSubscription = subscription;
   }

--- a/web/page0/src/app/store/store.ts
+++ b/web/page0/src/app/store/store.ts
@@ -1,5 +1,5 @@
 import {Injectable} from '@angular/core';
-import {Observable, Subject} from 'rxjs';
+import {Observable, ReplaySubject} from 'rxjs';
 import {map, scan, shareReplay, startWith} from 'rxjs/operators';
 import {Action, InitAction} from './actions';
 import {match} from './reducers';
@@ -11,7 +11,7 @@ import {AppState, INITIAL_STATE} from './state';
 export class Store {
   constructor() {}
 
-  action$ = new Subject<Action>();
+  action$ = new ReplaySubject<Action>();
 
   // should be updated by all reducers
   private state$ = this.action$.pipe(


### PR DESCRIPTION
There was a possibility of losing or invalid ordering of refresh events.

Modify to send and process events in the right order.