### PR TITLE
Apply staticchecker linter and resolve styling  issues.

### DIFF
--- a/cmd/cvdr/main.go
+++ b/cmd/cvdr/main.go
@@ -109,16 +109,16 @@ func (_ *cmdRunner) StartBgCommand(args ...string) ([]byte, error) {
 	cmd.Stdin = os.Stdin
 	pipe, err := cmd.StdoutPipe()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create pipe: %w", err)
+		return nil, fmt.Errorf("failed to create pipe: %w", err)
 	}
 	defer pipe.Close()
 	if err := cmd.Start(); err != nil {
-		return nil, fmt.Errorf("Unable to start command: %w", err)
+		return nil, fmt.Errorf("unable to start command: %w", err)
 	}
 	defer cmd.Process.Release()
 	output, err := io.ReadAll(pipe)
 	if err != nil {
-		return nil, fmt.Errorf("Error reading command output: %v", err)
+		return nil, fmt.Errorf("error reading command output: %v", err)
 	}
 	return output, nil
 }

--- a/pkg/app/accounts/gaeusers.go
+++ b/pkg/app/accounts/gaeusers.go
@@ -49,14 +49,14 @@ func (g *GAEUsersAccountManager) OnOAuth2Exchange(w http.ResponseWriter, r *http
 	}
 	email, ok := idToken["email"]
 	if !ok {
-		return nil, fmt.Errorf("No email in id token")
+		return nil, fmt.Errorf("no email in id token")
 	}
 	tkEmail, ok := email.(string)
 	if !ok {
-		return nil, fmt.Errorf("Malformed email in id token")
+		return nil, fmt.Errorf("malformed email in id token")
 	}
 	if rEmail != tkEmail {
-		return nil, fmt.Errorf("Logged in user doesn't match oauth2 user")
+		return nil, fmt.Errorf("logged in user doesn't match oauth2 user")
 	}
 	return userFromEmail(rEmail), nil
 }

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -292,11 +292,11 @@ func TestHostForwarderInvalidRequests(t *testing.T) {
 	for _, c := range cases {
 		u, err := url.Parse(c)
 		if err != nil {
-			t.Errorf("Failed to parse test url: %v", err)
+			t.Errorf("failed to parse test url: %v", err)
 		}
 		_, err = HostOrchestratorPath(u.Path, host)
 		if err == nil {
-			t.Errorf("Expected OrchestratorPath to fail")
+			t.Errorf("expected OrchestratorPath to fail")
 		}
 	}
 }
@@ -386,7 +386,7 @@ func TestHostForwarderDoesNotInjectCredentials(t *testing.T) {
 			t.Error(err)
 		}
 		if string(body) != string(msg) {
-			t.Errorf("Original message was modified by the controller: %q, expected: %q", string(body), string(msg))
+			t.Errorf("original message was modified by the controller: %q, expected: %q", string(body), string(msg))
 		}
 		w.Write([]byte("ok"))
 	}))

--- a/pkg/app/database/spanner.go
+++ b/pkg/app/database/spanner.go
@@ -64,7 +64,7 @@ func (dbs *SpannerDBService) FetchBuildAPICredentials(username string) ([]byte, 
 	ctx := context.TODO()
 	client, err := spanner.NewClient(ctx, dbs.db)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create db client: %w", err)
+		return nil, fmt.Errorf("failed to create db client: %w", err)
 	}
 	defer client.Close()
 
@@ -74,7 +74,7 @@ func (dbs *SpannerDBService) FetchBuildAPICredentials(username string) ([]byte, 
 			// Not found is not an error
 			return nil, nil
 		}
-		return nil, fmt.Errorf("Error querying database: %w", err)
+		return nil, fmt.Errorf("error querying database: %w", err)
 	}
 
 	var credentials []byte
@@ -141,7 +141,7 @@ func (dbs *SpannerDBService) FetchSession(key string) (*session.Session, error) 
 			// Not found is not an error
 			return nil, nil
 		}
-		return nil, fmt.Errorf("Failed to retrive session: %w", err)
+		return nil, fmt.Errorf("failed to retrive session: %w", err)
 	}
 	session := &session.Session{
 		Key:         key,

--- a/pkg/app/encryption/gcpkms.go
+++ b/pkg/app/encryption/gcpkms.go
@@ -40,7 +40,7 @@ func (s *GCPKMSEncryptionService) Encrypt(plaintext []byte) ([]byte, error) {
 	ctx := context.TODO()
 	client, err := kms.NewKeyManagementClient(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to instantiate KMS client: %w", err)
+		return nil, fmt.Errorf("failed to instantiate KMS client: %w", err)
 	}
 	defer client.Close()
 	req := &kmspb.EncryptRequest{
@@ -49,7 +49,7 @@ func (s *GCPKMSEncryptionService) Encrypt(plaintext []byte) ([]byte, error) {
 	}
 	result, err := client.Encrypt(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("Failed encryption request: %w", err)
+		return nil, fmt.Errorf("failed encryption request: %w", err)
 	}
 	return result.Ciphertext, nil
 }
@@ -58,7 +58,7 @@ func (s *GCPKMSEncryptionService) Decrypt(ciphertext []byte) ([]byte, error) {
 	ctx := context.TODO()
 	client, err := kms.NewKeyManagementClient(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to instantiate KMS client: %w", err)
+		return nil, fmt.Errorf("failed to instantiate KMS client: %w", err)
 	}
 	defer client.Close()
 	req := &kmspb.DecryptRequest{
@@ -67,7 +67,7 @@ func (s *GCPKMSEncryptionService) Decrypt(ciphertext []byte) ([]byte, error) {
 	}
 	result, err := client.Decrypt(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("Failed encryption request: %w", err)
+		return nil, fmt.Errorf("failed encryption request: %w", err)
 	}
 	return result.Plaintext, nil
 }

--- a/pkg/app/instances/hostclient.go
+++ b/pkg/app/instances/hostclient.go
@@ -65,7 +65,7 @@ func (c *NetHostClient) Get(path, query string, out *HostResponse) (int, error) 
 	url.RawQuery = query
 	res, err := c.client.Get(url.String())
 	if err != nil {
-		return -1, fmt.Errorf("Failed to connect to device host: %w", err)
+		return -1, fmt.Errorf("failed to connect to device host: %w", err)
 	}
 	defer res.Body.Close()
 	if out != nil {
@@ -77,14 +77,14 @@ func (c *NetHostClient) Get(path, query string, out *HostResponse) (int, error) 
 func (c *NetHostClient) Post(path, query string, bodyJSON any, out *HostResponse) (int, error) {
 	bodyStr, err := json.Marshal(bodyJSON)
 	if err != nil {
-		return -1, fmt.Errorf("Failed to parse JSON request: %w", err)
+		return -1, fmt.Errorf("failed to parse JSON request: %w", err)
 	}
 	url := *c.url // Shallow copy
 	url.Path = path
 	url.RawQuery = query
 	res, err := c.client.Post(url.String(), "application/json", bytes.NewBuffer(bodyStr))
 	if err != nil {
-		return -1, fmt.Errorf("Failed to connecto to device host: %w", err)
+		return -1, fmt.Errorf("failed to connecto to device host: %w", err)
 	}
 	defer res.Body.Close()
 	if out != nil {
@@ -111,7 +111,7 @@ func parseReply(res *http.Response, resObj any, resErr *apiv1.Error) error {
 		err = dec.Decode(resObj)
 	}
 	if err != nil {
-		return fmt.Errorf("Failed to parse device response: %w", err)
+		return fmt.Errorf("failed to parse device response: %w", err)
 	}
 	return nil
 }

--- a/pkg/app/oauth2/oauth2.go
+++ b/pkg/app/oauth2/oauth2.go
@@ -59,7 +59,7 @@ func NewGoogleOAuth2Helper(redirectURL string, sm secrets.SecretManager) *Helper
 
 func RevokeGoogleOAuth2Token(tk *oauth2.Token) error {
 	if tk == nil {
-		return fmt.Errorf("Nil Token")
+		return fmt.Errorf("nil Token")
 	}
 	_, err := http.DefaultClient.PostForm(
 		"https://oauth2.googleapis.com/revoke",

--- a/pkg/app/secrets/gcp.go
+++ b/pkg/app/secrets/gcp.go
@@ -42,19 +42,19 @@ func NewGCPSecretManager(config *GCPSMConfig) (*GCPSecretManager, error) {
 	ctx := context.TODO()
 	client, err := secretmanager.NewClient(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create secret manager client: %w", err)
+		return nil, fmt.Errorf("failed to create secret manager client: %w", err)
 	}
 	defer client.Close()
 
 	accessRequest := &secretmanagerpb.AccessSecretVersionRequest{Name: config.OAuth2ClientResourceID}
 	result, err := client.AccessSecretVersion(ctx, accessRequest)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to access secret: %w", err)
+		return nil, fmt.Errorf("failed to access secret: %w", err)
 	}
 	sm := &GCPSecretManager{}
 	err = json.Unmarshal(result.Payload.Data, &sm.secrets)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to decode secrets: %w", err)
+		return nil, fmt.Errorf("failed to decode secrets: %w", err)
 	}
 	return sm, nil
 }

--- a/pkg/cli/adbserver.go
+++ b/pkg/cli/adbserver.go
@@ -44,14 +44,14 @@ func (*ADBServerProxyImpl) sendMsg(msg string) error {
 	msg = fmt.Sprintf("%.4x%s", len(msg), msg)
 	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", ADBServerPort))
 	if err != nil {
-		return fmt.Errorf("Unable to contact ADB server: %w", err)
+		return fmt.Errorf("unable to contact ADB server: %w", err)
 	}
 	defer conn.Close()
 	written := 0
 	for written < len(msg) {
 		n, err := conn.Write([]byte(msg[written:]))
 		if err != nil {
-			return fmt.Errorf("Error sending message to ADB server: %w", err)
+			return fmt.Errorf("error sending message to ADB server: %w", err)
 		}
 		written += n
 	}

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -281,10 +281,10 @@ func PromptSelectionFromSlice[T any](c *command, choices []T, toStr func(T) stri
 	chosen := -1
 	_, err := fmt.Fscanln(c.InOrStdin(), &chosen)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to read choice: %w", err)
+		return nil, fmt.Errorf("failed to read choice: %w", err)
 	}
 	if chosen < 0 || chosen > maxChoice {
-		return nil, fmt.Errorf("Choice out of range: %d", chosen)
+		return nil, fmt.Errorf("choice out of range: %d", chosen)
 	}
 	if chosen < len(choices) {
 		return []T{choices[chosen]}, nil
@@ -313,10 +313,10 @@ func PromptSelectionFromMap[K comparable, T any](c *command, choices map[K]T, to
 	chosen := -1
 	_, err := fmt.Fscanln(c.InOrStdin(), &chosen)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to read choice: %w", err)
+		return nil, fmt.Errorf("failed to read choice: %w", err)
 	}
 	if chosen < 0 || chosen > maxChoice {
-		return nil, fmt.Errorf("Choice out of range: %d", chosen)
+		return nil, fmt.Errorf("choice out of range: %d", chosen)
 	}
 	if chosen < len(choices) {
 		key := keys[chosen]
@@ -573,11 +573,11 @@ func connectionCommands(opts *subCommandOpts) []*cobra.Command {
 func runCreateHostCommand(c *cobra.Command, flags *CreateHostFlags, opts *subCommandOpts) error {
 	service, err := opts.ServiceBuilder(flags.CVDRemoteFlags, c)
 	if err != nil {
-		return fmt.Errorf("Failed to build service instance: %w", err)
+		return fmt.Errorf("failed to build service instance: %w", err)
 	}
 	ins, err := createHost(service, *flags.CreateHostOpts)
 	if err != nil {
-		return fmt.Errorf("Failed to create host: %w", err)
+		return fmt.Errorf("failed to create host: %w", err)
 	}
 	c.Printf("%s\n", ins.Name)
 	return nil
@@ -590,7 +590,7 @@ func runListHostCommand(c *cobra.Command, flags *CVDRemoteFlags, opts *subComman
 	}
 	hosts, err := apiClient.ListHosts()
 	if err != nil {
-		return fmt.Errorf("Error listing hosts: %w", err)
+		return fmt.Errorf("error listing hosts: %w", err)
 	}
 	for _, ins := range hosts.Items {
 		c.Printf("%s\n", ins.Name)
@@ -623,12 +623,12 @@ func disconnectDevicesByHost(host string, opts *subCommandOpts) error {
 	controlDir := opts.InitialConfig.ConnectionControlDirExpanded()
 	statuses, err := listCVDConnectionsByHost(controlDir, host)
 	if err != nil {
-		return fmt.Errorf("Failed to list connections: %w", err)
+		return fmt.Errorf("failed to list connections: %w", err)
 	}
 	var merr error
 	for cvd, status := range statuses {
 		if err := DisconnectCVD(controlDir, cvd, status); err != nil {
-			merr = multierror.Append(merr, fmt.Errorf("Failed to disconnect from %s: %w", cvd.WebRTCDeviceID, err))
+			merr = multierror.Append(merr, fmt.Errorf("failed to disconnect from %s: %w", cvd.WebRTCDeviceID, err))
 		}
 	}
 	return merr
@@ -645,28 +645,28 @@ func runCreateCVDCommand(c *cobra.Command, args []string, flags *CreateCVDFlags,
 		filename := args[0]
 		data, err := os.ReadFile(filename)
 		if err != nil {
-			return fmt.Errorf("Invalid environment specification file %q: %w", filename, err)
+			return fmt.Errorf("invalid environment specification file %q: %w", filename, err)
 		}
 		envConfig := make(map[string]interface{})
 		if err := json.Unmarshal(data, &envConfig); err != nil {
-			return fmt.Errorf("Invalid environment specification: %w", err)
+			return fmt.Errorf("invalid environment specification: %w", err)
 		}
 		flags.CreateCVDOpts.EnvConfig = envConfig
 	}
 	if flags.NumInstances <= 0 {
-		return fmt.Errorf("Invalid --num_instances flag value: %d", flags.NumInstances)
+		return fmt.Errorf("invalid --num_instances flag value: %d", flags.NumInstances)
 	}
 	statePrinter := newStatePrinter(c.ErrOrStderr(), flags.Verbose)
 	service, err := opts.ServiceBuilder(flags.CVDRemoteFlags, c)
 	if err != nil {
-		return fmt.Errorf("Failed to build service instance: %w", err)
+		return fmt.Errorf("failed to build service instance: %w", err)
 	}
 	if flags.CreateCVDOpts.Host == "" {
 		statePrinter.Print(createHostStateMsg)
 		ins, err := createHost(service, *flags.CreateHostOpts)
 		statePrinter.PrintDone(createHostStateMsg, err)
 		if err != nil {
-			return fmt.Errorf("Failed to create host: %w", err)
+			return fmt.Errorf("failed to create host: %w", err)
 		}
 		flags.CreateCVDOpts.Host = ins.Name
 	}
@@ -685,7 +685,7 @@ func runCreateCVDCommand(c *cobra.Command, args []string, flags *CreateCVDFlags,
 			cvd.ConnStatus, err = ConnectDevice(flags.CreateCVDOpts.Host, cvd.WebRTCDeviceID, "", &command{c, &flags.Verbose}, opts)
 			statePrinter.PrintDone(fmt.Sprintf(connectCVDStateMsgFmt, cvd.WebRTCDeviceID), err)
 			if err != nil {
-				merr = multierror.Append(merr, fmt.Errorf("Failed to connect to device: %w", err))
+				merr = multierror.Append(merr, fmt.Errorf("failed to connect to device: %w", err))
 			}
 		}
 	}
@@ -735,7 +735,7 @@ func runPullCommand(c *cobra.Command, args []string, flags *CVDRemoteFlags, opts
 	case 1:
 		host = args[0]
 	default /* len(args) > 1 */ :
-		return errors.New("Invalid number of args")
+		return errors.New("invalid number of args")
 	}
 	f, err := os.CreateTemp("", "cvdrPull")
 	if err != nil {
@@ -767,7 +767,7 @@ func promptSingleHostNameSelection(c *command, service client.Service) (string, 
 func promptHostNameSelection(c *command, service client.Service, selOpt SelectionOption) ([]string, error) {
 	names, err := hostnames(service)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to list hosts: %w", err)
+		return nil, fmt.Errorf("failed to list hosts: %w", err)
 	}
 	if len(names) == 0 {
 		return []string{}, nil
@@ -798,7 +798,7 @@ func ConnectDevice(host, device, ice_config string, c *command, opts *subCommand
 
 	output, err := opts.CommandRunner.StartBgCommand(cmdArgs...)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to start connection agent: %w", err)
+		return nil, fmt.Errorf("unable to start connection agent: %w", err)
 	}
 
 	if len(output) == 0 {
@@ -806,12 +806,12 @@ func ConnectDevice(host, device, ice_config string, c *command, opts *subCommand
 		// No need to print error: the agent took care of that.
 		// This is not equivalent to reading more than zero bytes from stderr since the agent
 		// could write messages and warnings there without failing.
-		return nil, fmt.Errorf("No response from agent")
+		return nil, fmt.Errorf("no response from agent")
 	}
 
 	var status ConnStatus
 	if err := json.Unmarshal(output, &status); err != nil {
-		return nil, fmt.Errorf("Failed to decode agent output(%s): %w", string(output), err)
+		return nil, fmt.Errorf("failed to decode agent output(%s): %w", string(output), err)
 	}
 
 	return &status, nil
@@ -822,7 +822,7 @@ func runConnectCommand(flags *ConnectFlags, c *command, args []string, opts *sub
 		return err
 	}
 	if len(args) > 0 && flags.host == "" {
-		return fmt.Errorf("Missing host for devices: %v", args)
+		return fmt.Errorf("missing host for devices: %v", args)
 	}
 	service, err := opts.ServiceBuilder(flags.CVDRemoteFlags, c.Command)
 	if err != nil {
@@ -883,7 +883,7 @@ func runConnectCommand(flags *ConnectFlags, c *command, args []string, opts *sub
 			defer close(errCh)
 			status, err := ConnectDevice(cvd.Host, cvd.WebRTCDeviceID, flags.ice_config, c, opts)
 			if err != nil {
-				errCh <- fmt.Errorf("Failed to connect to %q on %q: %w", cvd.WebRTCDeviceID, cvd.Host, err)
+				errCh <- fmt.Errorf("failed to connect to %q on %q: %w", cvd.WebRTCDeviceID, cvd.Host, err)
 			} else {
 				connCh <- *status
 			}
@@ -907,7 +907,7 @@ func verifyICEConfigFlag(v string) (*wclient.ICEConfig, error) {
 	}
 	c, err := loadICEConfigFromFile(v)
 	if err != nil {
-		return nil, fmt.Errorf("Invalid --%s flag value: %w", iceConfigFlag, err)
+		return nil, fmt.Errorf("invalid --%s flag value: %w", iceConfigFlag, err)
 	}
 	return c, nil
 }
@@ -942,10 +942,10 @@ func runConnectionAgentCommand(flags *ConnectFlags, c *command, args []string, o
 		return err
 	}
 	if len(args) > 1 {
-		return fmt.Errorf("Connection agent only supports a single device, received: %v", args)
+		return fmt.Errorf("connection agent only supports a single device, received: %v", args)
 	}
 	if len(args) == 0 {
-		return fmt.Errorf("Missing device")
+		return fmt.Errorf("missing device")
 	}
 	device := args[0]
 	service, err := opts.ServiceBuilder(flags.CVDRemoteFlags, c.Command)
@@ -1013,7 +1013,7 @@ func runConnectionAgentCommand(flags *ConnectFlags, c *command, args []string, o
 
 func runDisconnectCommand(flags *ConnectFlags, c *command, args []string, opts *subCommandOpts) error {
 	if len(args) > 0 && flags.host == "" {
-		return fmt.Errorf("Missing host for devices: %v", args)
+		return fmt.Errorf("missing host for devices: %v", args)
 	}
 	controlDir := opts.InitialConfig.ConnectionControlDirExpanded()
 	var statuses map[RemoteCVDLocator]ConnStatus
@@ -1024,7 +1024,7 @@ func runDisconnectCommand(flags *ConnectFlags, c *command, args []string, opts *
 		statuses, merr = listCVDConnections(controlDir)
 	}
 	if len(statuses) == 0 {
-		return fmt.Errorf("No connections found")
+		return fmt.Errorf("no connections found")
 	}
 	// Restrict the list of connections to those specified as arguments
 	if len(args) > 0 {
@@ -1040,7 +1040,7 @@ func runDisconnectCommand(flags *ConnectFlags, c *command, args []string, opts *
 			return false
 		})
 		for device := range devices {
-			merr = multierror.Append(merr, fmt.Errorf("Connection not found for %q\n", device))
+			merr = multierror.Append(merr, fmt.Errorf("connection not found for %q", device))
 		}
 	}
 	if len(statuses) > 1 && !flags.skipConfirmation {
@@ -1114,7 +1114,7 @@ func buildServiceBuilder(builder client.ServiceBuilder) serviceBuilder {
 }
 
 func notImplementedCommand(c *cobra.Command, _ []string) error {
-	return fmt.Errorf("Command not implemented")
+	return fmt.Errorf("command not implemented")
 }
 
 func buildServiceRootEndpoint(serviceURL, zone string) string {

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -250,15 +250,15 @@ func TestBuildAgentCmdline(t *testing.T) {
 	subCmd, args, err := cmd.command.Traverse(args)
 	// This at least ensures no required flags were left blank.
 	if err != nil {
-		t.Errorf("Failed to parse args: %v", err)
+		t.Errorf("failed to parse args: %v", err)
 	}
 	// Just a sanity check that all flags were parsed and only the device was
 	// left as possitional argument.
 	if reflect.DeepEqual(args, []string{device}) {
-		t.Errorf("Expected resulting args to just have [%q], but found %v", device, args)
+		t.Errorf("expected resulting args to just have [%q], but found %v", device, args)
 	}
 	if subCmd.Name() != ConnectionAgentCommandName {
-		t.Errorf("Expected it to parse %q command, found: %q", ConnectionAgentCommandName, subCmd.Name())
+		t.Errorf("expected it to parse %q command, found: %q", ConnectionAgentCommandName, subCmd.Name())
 	}
 	// TODO(jemoreira): Compare the parsed flags with used flags
 }

--- a/pkg/cli/config.go
+++ b/pkg/cli/config.go
@@ -63,7 +63,7 @@ func BaseConfig() *Config {
 func LoadConfigFile(path string, c *Config) error {
 	b, err := os.ReadFile(path)
 	if err != nil {
-		return fmt.Errorf("Error reading config file: %w", err)
+		return fmt.Errorf("error reading config file: %w", err)
 	}
 	decoder := toml.NewDecoder(bytes.NewReader(b))
 	// Fail if there is some unknown configuration. This is better than silently

--- a/pkg/cli/config_test.go
+++ b/pkg/cli/config_test.go
@@ -38,7 +38,7 @@ MinCPUPlatform = "cpu_platform"
 	err := LoadConfigFile(fname, c)
 
 	if err != nil {
-		t.Errorf("Failed to parse config: %v", err)
+		t.Errorf("failed to parse config: %v", err)
 	}
 	// It's not necessary to check the value of each property because a successful
 	// parsing of the valid config above and a failed parsing of the config with
@@ -67,7 +67,7 @@ MinCPUPlatform = "cpu_platform"
 	// value to make it pass and ensure these tests apply to that field in the
 	// future.
 	if has, f := HasZeroes(*c); has {
-		t.Errorf("The Config's %s field was not parsed", f)
+		t.Errorf("the Config's %s field was not parsed", f)
 	}
 }
 
@@ -79,7 +79,7 @@ func TestLoadConfigFileInvalidConfig(t *testing.T) {
 	err := LoadConfigFile(fname, c)
 
 	if err == nil {
-		t.Errorf("Expected unknown config property to produce an error")
+		t.Errorf("expected unknown config property to produce an error")
 	}
 }
 

--- a/pkg/cli/cvd.go
+++ b/pkg/cli/cvd.go
@@ -89,7 +89,7 @@ func createCVD(service client.Service, createOpts CreateCVDOpts, statePrinter *s
 	creator := newCVDCreator(service, createOpts, statePrinter)
 	cvds, err := creator.Create()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create cvd: %w", err)
+		return nil, fmt.Errorf("failed to create cvd: %w", err)
 	}
 	result := []*RemoteCVD{}
 	for _, cvd := range cvds {
@@ -123,14 +123,14 @@ func (c *cvdCreator) Create() ([]*hoapi.CVD, error) {
 func (c *cvdCreator) createCVDFromLocalBuild() ([]*hoapi.CVD, error) {
 	vars, err := GetAndroidEnvVarValues()
 	if err != nil {
-		return nil, fmt.Errorf("Error retrieving Android Build environment variables: %w", err)
+		return nil, fmt.Errorf("error retrieving Android Build environment variables: %w", err)
 	}
 	names, err := ListLocalImageRequiredFiles(vars)
 	if err != nil {
-		return nil, fmt.Errorf("Error building list of required image files: %w", err)
+		return nil, fmt.Errorf("error building list of required image files: %w", err)
 	}
 	if err := verifyCVDHostPackageTar(vars.HostOut); err != nil {
-		return nil, fmt.Errorf("Invalid cvd host package: %w", err)
+		return nil, fmt.Errorf("invalid cvd host package: %w", err)
 	}
 	names = append(names, filepath.Join(vars.HostOut, CVDHostPackageName))
 	uploadDir, err := c.service.HostService(c.opts.Host).CreateUploadDir()
@@ -234,7 +234,7 @@ type cvdListResult struct {
 func listCVDs(service client.Service, controlDir string) ([]*RemoteHost, error) {
 	hl, err := service.ListHosts()
 	if err != nil {
-		return nil, fmt.Errorf("Error listing hosts: %w", err)
+		return nil, fmt.Errorf("error listing hosts: %w", err)
 	}
 	var hosts []string
 	for _, host := range hl.Items {
@@ -350,12 +350,12 @@ func ListLocalImageRequiredFiles(vars AndroidEnvVars) ([]string, error) {
 	reqImgsFilename := vars.BuildTop + "/" + RequiredImagesFilename
 	f, err := os.Open(reqImgsFilename)
 	if err != nil {
-		return nil, fmt.Errorf("Error opening the required images list file: %w", err)
+		return nil, fmt.Errorf("error opening the required images list file: %w", err)
 	}
 	defer f.Close()
 	content, err := os.ReadFile(reqImgsFilename)
 	if err != nil {
-		return nil, fmt.Errorf("Error reading the required images list file: %w", err)
+		return nil, fmt.Errorf("error reading the required images list file: %w", err)
 	}
 	contentStr := strings.TrimRight(string(content), "\n")
 	lines := strings.Split(contentStr, "\n")
@@ -369,14 +369,14 @@ func ListLocalImageRequiredFiles(vars AndroidEnvVars) ([]string, error) {
 func verifyCVDHostPackageTar(dir string) error {
 	tarInfo, err := os.Stat(filepath.Join(dir, CVDHostPackageName))
 	if errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("%q not found. Please run `m hosttar`.", CVDHostPackageName)
+		return fmt.Errorf("%q not found. Please run `m hosttar`", CVDHostPackageName)
 	}
 	dirInfo, err := os.Stat(filepath.Join(dir, CVDHostPackageDirName))
 	if err != nil {
-		return fmt.Errorf("Failed getting cvd host package directory info: %w", err)
+		return fmt.Errorf("failed getting cvd host package directory info: %w", err)
 	}
 	if tarInfo.ModTime().Before(dirInfo.ModTime()) {
-		return fmt.Errorf("%q out of date. Please run `m hosttar`.", CVDHostPackageName)
+		return fmt.Errorf("%q out of date. Please run `m hosttar`", CVDHostPackageName)
 	}
 	return nil
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -122,7 +122,7 @@ func (c *serviceImpl) CreateHost(req *apiv1.CreateHostRequest) (*apiv1.HostInsta
 	}
 	hostPath := fmt.Sprintf("/hosts/%s/", ins.Name)
 	if err := c.httpHelper.NewGetRequest(hostPath).DoWithRetries(nil, retryOpts); err != nil {
-		return nil, fmt.Errorf("Unable to communicate with host orchestrator: %w", err)
+		return nil, fmt.Errorf("unable to communicate with host orchestrator: %w", err)
 	}
 
 	return ins, nil
@@ -147,7 +147,7 @@ func (c *serviceImpl) DeleteHosts(names []string) error {
 			if err := c.httpHelper.NewDeleteRequest("/hosts/" + name).Do(nil); err != nil {
 				mu.Lock()
 				defer mu.Unlock()
-				merr = multierror.Append(merr, fmt.Errorf("Delete host %q failed: %w", name, err))
+				merr = multierror.Append(merr, fmt.Errorf("delete host %q failed: %w", name, err))
 			}
 		}(name)
 	}

--- a/pkg/client/host_orchestrator_client.go
+++ b/pkg/client/host_orchestrator_client.go
@@ -89,7 +89,7 @@ func (c *HostOrchestratorServiceImpl) getInfraConfig() (*hoapi.InfraConfig, erro
 func (c *HostOrchestratorServiceImpl) ConnectWebRTC(device string, observer wclient.Observer, logger io.Writer, opts ConnectWebRTCOpts) (*wclient.Connection, error) {
 	polledConn, err := c.createPolledConnection(device)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create polled connection: %w", err)
+		return nil, fmt.Errorf("failed to create polled connection: %w", err)
 	}
 	iceServers := []webrtc.ICEServer{}
 	if opts.LocalICEConfig != nil {
@@ -97,13 +97,13 @@ func (c *HostOrchestratorServiceImpl) ConnectWebRTC(device string, observer wcli
 	}
 	infraConfig, err := c.getInfraConfig()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to obtain infra config: %w", err)
+		return nil, fmt.Errorf("failed to obtain infra config: %w", err)
 	}
 	iceServers = append(iceServers, asWebRTCICEServers(infraConfig.IceServers)...)
 	signaling := c.initHandling(polledConn.ConnId, iceServers, logger)
 	conn, err := wclient.NewConnectionWithLogger(&signaling, observer, logger)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to connect to device over webrtc: %w", err)
+		return nil, fmt.Errorf("failed to connect to device over webrtc: %w", err)
 	}
 	return conn, nil
 }

--- a/pkg/client/httputils.go
+++ b/pkg/client/httputils.go
@@ -83,7 +83,7 @@ func (h *HTTPHelper) dumpRequest(r *http.Request) error {
 	}
 	dump, err := httputil.DumpRequestOut(r, true)
 	if err != nil {
-		return fmt.Errorf("Error dumping request: %w", err)
+		return fmt.Errorf("error dumping request: %w", err)
 	}
 	fmt.Fprintf(h.Dumpster, "%s\n", dump)
 	return nil
@@ -95,7 +95,7 @@ func (h *HTTPHelper) dumpResponse(r *http.Response) error {
 	}
 	dump, err := httputil.DumpResponse(r, true)
 	if err != nil {
-		return fmt.Errorf("Error dumping response: %w", err)
+		return fmt.Errorf("error dumping response: %w", err)
 	}
 	fmt.Fprintf(h.Dumpster, "%s\n", dump)
 	return nil
@@ -140,7 +140,7 @@ func (rb *HTTPRequestBuilder) DoWithRetries(ret any, retryOpts RetryOptions) err
 	}
 	res, err := rb.helper.Client.Do(rb.request)
 	if err != nil {
-		return fmt.Errorf("Error sending request: %w", err)
+		return fmt.Errorf("error sending request: %w", err)
 	}
 	for i := uint(0); i < retryOpts.NumRetries && isIn(res.StatusCode, retryOpts.StatusCodes); i++ {
 		err = rb.helper.dumpResponse(res)
@@ -150,7 +150,7 @@ func (rb *HTTPRequestBuilder) DoWithRetries(ret any, retryOpts RetryOptions) err
 		}
 		time.Sleep(retryOpts.RetryDelay)
 		if res, err = rb.helper.Client.Do(rb.request); err != nil {
-			return fmt.Errorf("Error sending request: %w", err)
+			return fmt.Errorf("error sending request: %w", err)
 		}
 	}
 	defer res.Body.Close()
@@ -165,13 +165,13 @@ func (rb *HTTPRequestBuilder) parseResponse(res *http.Response, ret any) error {
 	if res.StatusCode < 200 || res.StatusCode > 299 {
 		errpl := new(ApiCallError)
 		if err := dec.Decode(errpl); err != nil {
-			return fmt.Errorf("Error decoding response: %w", err)
+			return fmt.Errorf("error decoding response: %w", err)
 		}
 		return errpl
 	}
 	if ret != nil {
 		if err := dec.Decode(ret); err != nil {
-			return fmt.Errorf("Error decoding response: %w", err)
+			return fmt.Errorf("error decoding response: %w", err)
 		}
 	}
 	return nil
@@ -387,8 +387,8 @@ func (w *uploadChunkWorker) upload(job uploadChunkJob) error {
 		return err
 	}
 	if res.StatusCode != 200 {
-		const msg = "Failed uploading file chunk with status code %q. " +
-			"File %q, chunk number: %d, chunk total: %d."
+		const msg = "failed uploading file chunk with status code %q. " +
+			"File %q, chunk number: %d, chunk total: %d"
 		return fmt.Errorf(msg, res.Status, filepath.Base(job.Filename), job.ChunkNumber, job.TotalChunks)
 	}
 	return nil

--- a/pkg/webrtcclient/client.go
+++ b/pkg/webrtcclient/client.go
@@ -49,11 +49,11 @@ func (c *Controller) connect(onComplete func(error)) {
 			// Connected successfully
 			onComplete(nil)
 		case webrtc.PeerConnectionStateFailed:
-			onComplete(fmt.Errorf("Peer Connection failed"))
+			onComplete(fmt.Errorf("peer Connection failed"))
 			c.observer.OnFailure()
 			c.stopGoRoutines()
 		case webrtc.PeerConnectionStateClosed:
-			onComplete(fmt.Errorf("Peer Connection closed unexpectedly"))
+			onComplete(fmt.Errorf("peer Connection closed unexpectedly"))
 			c.observer.OnClose()
 			c.stopGoRoutines()
 		default:
@@ -100,7 +100,7 @@ func (c *Controller) recvLoop() error {
 				panic(fmt.Sprintf("Failed to reshape json: %v", err))
 			}
 			if err := c.onOffer(offer); err != nil {
-				return fmt.Errorf("Error handling offer: %w", err)
+				return fmt.Errorf("error handling offer: %w", err)
 			}
 		case ICECandidateMsgType:
 			candidate, err := Reshape[webrtc.ICECandidateInit](msg)
@@ -109,7 +109,7 @@ func (c *Controller) recvLoop() error {
 				panic(fmt.Sprintf("Failed to reshape json: %v", err))
 			}
 			if err := c.onICECandidate(candidate); err != nil {
-				return fmt.Errorf("Error handling ICE candidate: %w", err)
+				return fmt.Errorf("error handling ICE candidate: %w", err)
 			}
 		case AnswerMsgType:
 			answer, err := Reshape[webrtc.SessionDescription](msg)
@@ -118,13 +118,13 @@ func (c *Controller) recvLoop() error {
 				panic(fmt.Sprintf("Failed to reshape json: %v", err))
 			}
 			if err := c.onAnswer(answer); err != nil {
-				return fmt.Errorf("Error handling answer: %w", err)
+				return fmt.Errorf("error handling answer: %w", err)
 			}
 		default:
 			if errMsg, errPresent := msg["error"]; errPresent {
-				return fmt.Errorf("Received error from signaling server: %v", errMsg)
+				return fmt.Errorf("received error from signaling server: %v", errMsg)
 			} else {
-				return fmt.Errorf("Unknown message type: %v", msg["type"])
+				return fmt.Errorf("unknown message type: %v", msg["type"])
 			}
 		}
 	}
@@ -160,14 +160,14 @@ func (c *Controller) sendSigMsg(msg any) {
 
 func (c *Controller) onOffer(offer *webrtc.SessionDescription) error {
 	if err := c.peerConnection.SetRemoteDescription(*offer); err != nil {
-		return fmt.Errorf("Failed to set remote description: %w", err)
+		return fmt.Errorf("failed to set remote description: %w", err)
 	}
 	answer, err := c.peerConnection.CreateAnswer(nil)
 	if err != nil {
-		return fmt.Errorf("Failed to create answer: %w", err)
+		return fmt.Errorf("failed to create answer: %w", err)
 	}
 	if err = c.peerConnection.SetLocalDescription(answer); err != nil {
-		return fmt.Errorf("Failed to set local description: %w", err)
+		return fmt.Errorf("failed to set local description: %w", err)
 	}
 	c.sendSigMsg(answer)
 	return nil
@@ -176,7 +176,7 @@ func (c *Controller) onOffer(offer *webrtc.SessionDescription) error {
 func (c *Controller) onAnswer(answer *webrtc.SessionDescription) error {
 	err := c.peerConnection.SetRemoteDescription(*answer)
 	if err != nil {
-		return fmt.Errorf("Failed to set remote description: %w", err)
+		return fmt.Errorf("failed to set remote description: %w", err)
 	}
 	return nil
 }
@@ -184,7 +184,7 @@ func (c *Controller) onAnswer(answer *webrtc.SessionDescription) error {
 func (c *Controller) onICECandidate(candidate *webrtc.ICECandidateInit) error {
 	err := c.peerConnection.AddICECandidate(*candidate)
 	if err != nil {
-		return fmt.Errorf("Failed to add ICE candidate: %w", err)
+		return fmt.Errorf("failed to add ICE candidate: %w", err)
 	}
 	return nil
 }
@@ -227,11 +227,11 @@ func NewConnectionWithLogger(signaling *Signaling, observer Observer, logger io.
 	}
 	pc, err := api.NewPeerConnection(cfg)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create peer connection: %w", err)
+		return nil, fmt.Errorf("failed to create peer connection: %w", err)
 	}
 	adbChannel, err := pc.CreateDataChannel("adb-channel", nil /*options*/)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create adb data channel: %w", err)
+		return nil, fmt.Errorf("failed to create adb data channel: %w", err)
 	}
 	pc.OnNegotiationNeeded(func() {
 		// TODO(jemoreira): This needs to be handled when unnecessary tracks and

--- a/pkg/webrtcclient/client_test.go
+++ b/pkg/webrtcclient/client_test.go
@@ -62,13 +62,13 @@ func (o *TestObserver) OnError(err error) {
 
 func (o *TestObserver) OnClose() {
 	if o.onError != nil {
-		o.onError(fmt.Errorf("Connection closed"))
+		o.onError(fmt.Errorf("connection closed"))
 	}
 }
 
 func (o *TestObserver) OnFailure() {
 	if o.onError != nil {
-		o.onError(fmt.Errorf("Connection failed"))
+		o.onError(fmt.Errorf("connection failed"))
 	}
 }
 

--- a/pkg/webrtcclient/types.go
+++ b/pkg/webrtcclient/types.go
@@ -60,12 +60,12 @@ func NewICECandidateMsg(candidate webrtc.ICECandidateInit) *ICECandidateMsg {
 func Reshape[K any](original any) (*K, error) {
 	str, err := json.Marshal(original)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to marshal original message: %v", err)
+		return nil, fmt.Errorf("failed to marshal original message: %v", err)
 	}
 	var ret K
 	err = json.Unmarshal(str, &ret)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to unmarshal into new object: %v", err)
+		return nil, fmt.Errorf("failed to unmarshal into new object: %v", err)
 	}
 	return &ret, nil
 }


### PR DESCRIPTION
Resolved patterns:
ST1005 {error  messages}
error strings should not be capitalized

[reference](https://google.github.io/styleguide/go/decisions.html#error-strings)