### PR TITLE
Eliminate Typos and Misspellings for Enhanced Readability

### DIFF
--- a/api/v1/instancemanager.go
+++ b/api/v1/instancemanager.go
@@ -61,7 +61,7 @@ type ListHostsResponse struct {
 	NextPageToken string `json:"nextPageToken,omitempty"`
 }
 
-// To be seperated in to new file if the config needs to contain intormation other than instance manager
+// To be separated in to new file if the config needs to contain intormation other than instance manager
 type Config struct {
 	InstanceManagerType string `json:"instance_manager_type"`
 }

--- a/pkg/app/database/spanner.go
+++ b/pkg/app/database/spanner.go
@@ -141,7 +141,7 @@ func (dbs *SpannerDBService) FetchSession(key string) (*session.Session, error) 
 			// Not found is not an error
 			return nil, nil
 		}
-		return nil, fmt.Errorf("failed to retrive session: %w", err)
+		return nil, fmt.Errorf("failed to retrieve session: %w", err)
 	}
 	session := &session.Session{
 		Key:         key,

--- a/pkg/app/errors/errors.go
+++ b/pkg/app/errors/errors.go
@@ -63,7 +63,7 @@ func NewInternalError(msg string, e error) error {
 
 func NewUnauthenticatedError(msg string, e error) error {
 	// 401 Unauthorized semantically means "Unauthenticated, while authorization errors are to be
-	// returned with 403 Forbiden according to
+	// returned with 403 Forbidden according to
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses.
 	return &AppError{Msg: msg, StatusCode: http.StatusUnauthorized, Err: e}
 }

--- a/pkg/app/instances/hostclient.go
+++ b/pkg/app/instances/hostclient.go
@@ -45,7 +45,7 @@ func NewNetHostClient(url *url.URL, allowSelfSigned bool) *NetHostClient {
 		defaultTransport := http.DefaultTransport.(*http.Transport)
 		transport := &http.Transport{
 			Proxy: defaultTransport.Proxy,
-			// Reusing the same dial context allows reusing connections accross transport objects.
+			// Reusing the same dial context allows reusing connections across transport objects.
 			DialContext:           defaultTransport.DialContext,
 			ForceAttemptHTTP2:     defaultTransport.ForceAttemptHTTP2,
 			MaxIdleConns:          defaultTransport.MaxIdleConns,

--- a/pkg/cli/config.go
+++ b/pkg/cli/config.go
@@ -67,7 +67,7 @@ func LoadConfigFile(path string, c *Config) error {
 	}
 	decoder := toml.NewDecoder(bytes.NewReader(b))
 	// Fail if there is some unknown configuration. This is better than silently
-	// ignoring a (perhaps mispelled) config entry.
+	// ignoring a (perhaps misspelled) config entry.
 	decoder.Strict(true)
 	return decoder.Decode(c)
 }

--- a/web/intercept/js/server_connector.js
+++ b/web/intercept/js/server_connector.js
@@ -48,7 +48,7 @@ export async function createConnector() {
 
 // A connector object provides high level functions for communicating with the
 // signaling server, while hiding away implementation details.
-// This class is an interface and shouldn't be instantiated direclty.
+// This class is an interface and shouldn't be instantiated directly.
 // Only the public methods present in this class form part of the Server
 // Connector Interface, any implementations of the interface are considered
 // internal and not accessible to client code.

--- a/web/page0/src/http_interceptors/auth.interceptor.ts
+++ b/web/page0/src/http_interceptors/auth.interceptor.ts
@@ -27,7 +27,7 @@ export class AuthInterceptor implements HttpInterceptor {
   ): Observable<HttpEvent<unknown>> {
     return next.handle(request).pipe(
       catchError((error: HttpErrorResponse) => {
-        // If credentails got expired, OPTIONS request fails before the actual request
+        // If credentials got expired, OPTIONS request fails before the actual request
         // Thus, error status becomes 0 for CORS failure
         if (error.status === 0) {
           handleAuthError(error, this.snackBar);


### PR DESCRIPTION
This commit utilizes the misspell tool to identify and correct typos and spelling mistakes across the codebase.

This improves the overall readability and clarity of the code for developers and users alike.