### PR TITLE
Enable GitHub Matrix Strategy for Golang Versions

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -5,13 +5,16 @@ on: [pull_request, push]
 jobs:
   build-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ['1.19.0']
     steps:
     - name: Checkout repository
       uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # aka v2
     - name: Install dependencies
       uses: actions/setup-go@v3
       with:
-        go-version: '1.19.0'
+        go-version: ${{ matrix.go-version }}
     - run: go version
     - name: Build
       run: go build ./...

--- a/.github/workflows/build_debian_packages.yaml
+++ b/.github/workflows/build_debian_packages.yaml
@@ -5,6 +5,9 @@ on: [pull_request, push]
 jobs:
   build-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ['1.19.0']
     container:
       image: debian@sha256:6a8bad8d20e1ca5ecbb7a314e51df6fca73fcce19af2778550671bdd1cbe7b43 # aka stable-20211011
     steps:
@@ -15,7 +18,7 @@ jobs:
     - name: Install dependencies
       uses: actions/setup-go@v3
       with:
-        go-version: '1.19.0'
+        go-version: ${{ matrix.go-version }}
     - name: install debuild dependencies
       run: apt install -y git devscripts config-package-dev debhelper-compat golang
     - name: Build

--- a/.github/workflows/build_debian_packages.yaml
+++ b/.github/workflows/build_debian_packages.yaml
@@ -3,7 +3,7 @@ name: Build Debian packages
 on: [pull_request, push]
 
 jobs:
-  build-test:
+  build-test-debian-package:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/check_format.yaml
+++ b/.github/workflows/check_format.yaml
@@ -5,13 +5,16 @@ on: [pull_request, push]
 jobs:
   check-format:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ['1.19.0']
     steps:
     - name: Checkout repository
       uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # aka v2
     - name: Install dependencies
       uses: actions/setup-go@v3
       with:
-        go-version: '1.19.0'
+        go-version: ${{ matrix.go-version }}
     - run: go version
     - name: Check format
       run: if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then exit 1; fi


### PR DESCRIPTION
This change  enables utilization Matrix strategy for our workflows.
This allows for comprehensive testing and validation of our codebase against various Golang versions.

Benefits:
- forward or backward compatibility
- identifying Depredations

for tech details please check 
https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs