### PR TITLE
⬆️ Upgrade Go Language Version to Address Compatibility Issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/cloud-android-orchestration
 
-go 1.18
+go 1.19
 
 require (
 	cloud.google.com/go/kms v1.10.2


### PR DESCRIPTION
This commit upgrades the Go language version specified in the go.mod file from go 1.18 to go 1.19. 

This addresses compatibility issues identified during testing against different Go versions.

Motivation:
- Backward compatibility testing against Go 1.18 revealed an error in pkg/cli/conn.go:159:23: undefined: atomic.Bool.
- Further investigation linked the error to the usage of atomic.Bool, which was introduced in Go 1.19.
- Reference: https://pkg.go.dev/sync/atomic#Bool

Solution:
- Upgrade Go language version to go 1.19 in the go.mod file.
This ensures compatibility with features like atomic.Bool used in the codebase.