### PR TITLE
Make running the cloud and host orchestrators locally easy and convenient.

### DIFF
--- a/build/package/host/etc/cvdr.toml
+++ b/build/package/host/etc/cvdr.toml
@@ -25,6 +25,12 @@
 # files forever.
 # KeepLogFilesDays = 30
 
+# Source for the Build API credentials to be used on cvd create operations.
+# Possible values are:
+#  - "none": Don't use Build API credentials.
+#  - "injected": Use credentials stored in the server.
+# BuildAPICredentialsSource = "injected"
+
 # The host.GCP section provides default configuration values for hosts created
 # using the GCP Cloud Provider. Other providers will have their own
 # host.<Provider> sections when added.

--- a/cmd/cloud_orchestrator/main.go
+++ b/cmd/cloud_orchestrator/main.go
@@ -81,6 +81,8 @@ func LoadSecretManager(config *config.Config) secrets.SecretManager {
 		if err != nil {
 			log.Fatal(err)
 		}
+	case secrets.EmptySMType:
+		return secrets.NewEmptySecretManager()
 	default:
 		log.Fatal("Unknown Secret Manager type: ", config.SecretManager.Type)
 	}

--- a/conf.toml
+++ b/conf.toml
@@ -12,7 +12,7 @@ Provider = "Google"
 RedirectURL = "http://localhost:8080/oauth2callback"
 
 [SecretManager]
-Type = "unix"
+Type = ""
 
 [SecretManager.GCP]
 OAuth2ClientResourceID = ""

--- a/conf.toml
+++ b/conf.toml
@@ -43,7 +43,7 @@ HostImageFamily = ""
 HostOrchestratorPort = 1080
 
 [InstanceManager.UNIX]
-HostOrchestratorPort = 1081
+HostOrchestratorPort = 2080
 
 [WebRTC]
 STUNServers = ["stun:stun.l.google.com:19302"]

--- a/pkg/app/secrets/empty.go
+++ b/pkg/app/secrets/empty.go
@@ -17,7 +17,7 @@ package secrets
 const EmptySMType = ""
 
 // A secret manager that always returns empty string.
-type EmptySecretManager struct {}
+type EmptySecretManager struct{}
 
 func NewEmptySecretManager() *EmptySecretManager {
 	return &EmptySecretManager{}
@@ -30,4 +30,3 @@ func (sm *EmptySecretManager) OAuth2ClientID() string {
 func (sm *EmptySecretManager) OAuth2ClientSecret() string {
 	return ""
 }
-

--- a/pkg/app/secrets/empty.go
+++ b/pkg/app/secrets/empty.go
@@ -1,0 +1,33 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secrets
+
+const EmptySMType = ""
+
+// A secret manager that always returns empty string.
+type EmptySecretManager struct {}
+
+func NewEmptySecretManager() *EmptySecretManager {
+	return &EmptySecretManager{}
+}
+
+func (sm *EmptySecretManager) OAuth2ClientID() string {
+	return ""
+}
+
+func (sm *EmptySecretManager) OAuth2ClientSecret() string {
+	return ""
+}
+

--- a/pkg/app/secrets/local.go
+++ b/pkg/app/secrets/local.go
@@ -16,6 +16,7 @@ package secrets
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 )
 
@@ -34,7 +35,7 @@ type FromFileSecretManager struct {
 func NewFromFileSecretManager(path string) (*FromFileSecretManager, error) {
 	r, err := os.Open(path)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to open secrets file: %w", err)
 	}
 	dec := json.NewDecoder(r)
 	var sm FromFileSecretManager

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -97,6 +97,7 @@ const (
 	systemImgBuildTargetFlag  = "system_build_target"
 	numInstancesFlag          = "num_instances"
 	autoConnectFlag           = "auto_connect"
+	credentialsSourceFlag     = "credentials_source"
 )
 
 const (
@@ -488,6 +489,8 @@ func cvdCommands(opts *subCommandOpts) []*cobra.Command {
 		"Creates multiple instances with the same artifacts. Only relevant if given a single build source")
 	create.Flags().BoolVar(&createFlags.AutoConnect, autoConnectFlag, true,
 		"Automatically connect through ADB after device is created.")
+	create.Flags().StringVar(&createFlags.BuildAPICredentialsSource, credentialsSourceFlag, opts.InitialConfig.BuildAPICredentialsSource,
+		"Source for the Build API OAuth2 credentials")
 	// Host flags
 	createHostFlags := []struct {
 		ValueRef *string

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -204,7 +204,8 @@ func TestCommandSucceeds(t *testing.T) {
 				IOStreams: io,
 				Args:      append(test.Args, "--service_url="+serviceURL),
 				InitialConfig: Config{
-					ConnectionControlDir: t.TempDir(),
+					ConnectionControlDir:      t.TempDir(),
+					BuildAPICredentialsSource: "none",
 				},
 				ServiceBuilder: func(opts *client.ServiceOptions) (client.Service, error) {
 					return &fakeService{}, nil

--- a/pkg/cli/config.go
+++ b/pkg/cli/config.go
@@ -36,12 +36,13 @@ type HostConfig struct {
 }
 
 type Config struct {
-	ServiceURL           string
-	Zone                 string
-	HTTPProxy            string
-	ConnectionControlDir string
-	KeepLogFilesDays     int
-	Host                 HostConfig
+	ServiceURL                string
+	Zone                      string
+	HTTPProxy                 string
+	ConnectionControlDir      string
+	KeepLogFilesDays          int
+	BuildAPICredentialsSource string
+	Host                      HostConfig
 }
 
 func (c *Config) ConnectionControlDirExpanded() string {
@@ -54,8 +55,9 @@ func (c *Config) LogFilesDeleteThreshold() time.Duration {
 
 func BaseConfig() *Config {
 	return &Config{
-		ConnectionControlDir: "~/.cvdr/connections",
-		KeepLogFilesDays:     30, // A default is needed to not keep forever
+		ConnectionControlDir:      "~/.cvdr/connections",
+		KeepLogFilesDays:          30,                    // A default is needed to not keep forever
+		BuildAPICredentialsSource: NoneCredentialsSource, // Default needed because empty string is invalid
 	}
 }
 

--- a/pkg/cli/config_test.go
+++ b/pkg/cli/config_test.go
@@ -100,10 +100,11 @@ MachineType = "machine-type-bar"
 	scf := tempFile(t, system)
 	ucf := tempFile(t, user)
 	expected := &Config{
-		ServiceURL:           "service-foo",
-		Zone:                 "zone-bar",
-		KeepLogFilesDays:     0,
-		ConnectionControlDir: "~/.cvdr/connections",
+		ServiceURL:                "service-foo",
+		Zone:                      "zone-bar",
+		KeepLogFilesDays:          0,
+		ConnectionControlDir:      "~/.cvdr/connections",
+		BuildAPICredentialsSource: NoneCredentialsSource,
 		Host: HostConfig{
 			GCP: GCPHostConfig{
 				MachineType:    "machine-type-bar",


### PR DESCRIPTION
After this you can run these commands to test the system end to end:
```
$ cvd_host_orchestrator 2>ho.err >ho.out & # requires cuttlefish-user v0.9.28
$ go build ./cmd/cloud_orchestrator/ && ./cloud-orchestrator &
$ go build ./cmd/cvdr && ./cvdr --service_url=http://localhost:8080 --zone=z create --host=local --credential_source=none 
```