### PR TITLE
Create skeleton code for IM(InstanceManager) Type - docker

### DIFF
--- a/cmd/cloud_orchestrator/main.go
+++ b/cmd/cloud_orchestrator/main.go
@@ -60,6 +60,8 @@ func LoadInstanceManager(config *config.Config) instances.Manager {
 		im = instances.NewGCEInstanceManager(config.InstanceManager, service, nameGenerator)
 	case instances.UnixIMType:
 		im = instances.NewLocalInstanceManager(config.InstanceManager)
+	case instances.DockerIMType:
+		im = instances.NewDockerInstanceManager(config.InstanceManager)
 	default:
 		log.Fatal("Unknown Instance Manager type: ", config.InstanceManager.Type)
 	}

--- a/pkg/app/instances/docker.go
+++ b/pkg/app/instances/docker.go
@@ -1,0 +1,63 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package instances
+
+import (
+	"fmt"
+
+	apiv1 "github.com/google/cloud-android-orchestration/api/v1"
+	"github.com/google/cloud-android-orchestration/pkg/app/accounts"
+)
+
+const DockerIMType IMType = "docker"
+
+type DockerIMConfig struct {
+	HostOrchestratorPort int
+}
+
+// Docker implementation of the instance manager.
+type DockerInstanceManager struct {
+	Config Config
+}
+
+func NewDockerInstanceManager(cfg Config) *DockerInstanceManager {
+	return &DockerInstanceManager{
+		Config: cfg,
+	}
+}
+
+func (m *DockerInstanceManager) ListZones() (*apiv1.ListZonesResponse, error) {
+	return nil, fmt.Errorf("%T#ListZones is not implemented", *m)
+}
+
+func (m *DockerInstanceManager) CreateHost(_ string, _ *apiv1.CreateHostRequest, _ accounts.User) (*apiv1.Operation, error) {
+	return nil, fmt.Errorf("%T#CreateHost is not implemented", *m)
+}
+
+func (m *DockerInstanceManager) ListHosts(zone string, user accounts.User, req *ListHostsRequest) (*apiv1.ListHostsResponse, error) {
+	return nil, fmt.Errorf("%T#ListHosts is not implemented", *m)
+}
+
+func (m *DockerInstanceManager) DeleteHost(zone string, user accounts.User, name string) (*apiv1.Operation, error) {
+	return nil, fmt.Errorf("%T#DeleteHost is not implemented", *m)
+}
+
+func (m *DockerInstanceManager) WaitOperation(zone string, user accounts.User, name string) (any, error) {
+	return nil, fmt.Errorf("%T#WaitOperation is not implemented", *m)
+}
+
+func (m *DockerInstanceManager) GetHostClient(zone string, host string) (HostClient, error) {
+	return nil, fmt.Errorf("%T#GetHostClient is not implemented", *m)
+}

--- a/pkg/app/instances/instances.go
+++ b/pkg/app/instances/instances.go
@@ -70,4 +70,5 @@ type Config struct {
 	AllowSelfSignedHostSSLCertificate bool
 	GCP                               *GCPIMConfig
 	UNIX                              *UNIXIMConfig
+	Docker                            *DockerIMConfig
 }


### PR DESCRIPTION
Currently, there's no sufficient type to support containerized instance.
Of course we cannot use GCE IM type for ARM servers based on Docker.
Also using Unix IM type is restricted, since it's designed for supporting single Host Orchestrator.

In my idea, docker IM Type aims:
- Single Zone (Server itself)
- Multiple Host (One Host - One Docker instance)