### PR TITLE
Make available handling /v1/zones/{zone}/hosts/{host}/infra_config by CO

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -109,12 +109,6 @@ func (c *App) Handler() http.Handler {
 	// Host Orchestrator Proxy Routes
 	router.Handle("/v1/zones/{zone}/hosts/{host}/{hostPath:.*}", c.Authenticate(c.ForwardToHost))
 
-	// Infra route
-	router.HandleFunc("/v1/zones/{zone}/hosts/{host}/infra_config", func(w http.ResponseWriter, r *http.Request) {
-		// TODO(b/220891296): Make this configurable
-		replyJSON(w, c.InfraConfig(), http.StatusOK)
-	}).Methods("GET")
-
 	// Global routes
 	router.Handle("/auth", HTTPHandler(c.AuthHandler)).Methods("GET")
 	router.Handle("/oauth2callback", HTTPHandler(c.OAuth2Callback))
@@ -149,6 +143,12 @@ const (
 
 func (a *App) ForwardToHost(w http.ResponseWriter, r *http.Request, user accounts.User) error {
 	hostPath := "/" + mux.Vars(r)["hostPath"]
+
+	// Intercept /infra_config
+	if hostPath == "/infra_config" && r.Method == "GET" {
+		replyJSON(w, a.InfraConfig(), http.StatusOK)
+		return nil
+	}
 
 	if interceptFile, found := a.findInterceptFile(hostPath); found {
 		http.ServeFile(w, r, interceptFile)

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -24,7 +24,6 @@ import (
 	"net/http/httptest"
 	"net/http/httputil"
 	"net/url"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -225,24 +224,21 @@ func TestInfraConfigRequest(t *testing.T) {
 
 	res, _ := http.Get(ts.URL + "/v1/zones/foo/hosts/bar/infra_config")
 
-	expectedStatus := http.StatusOK
-	if res.StatusCode != expectedStatus {
-		t.Errorf("unexpected status code <<%d>>, want: %d", res.StatusCode, expectedStatus)
+	if diff := cmp.Diff(http.StatusOK, res.StatusCode); diff != "" {
+		t.Errorf("status mismatch (-expected +got):\n%s", diff)
 	}
-
 	rBody, err := io.ReadAll(res.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
-	var actualInfraConfig apiv1.InfraConfig
-	err = json.Unmarshal(rBody, &actualInfraConfig)
+	var got apiv1.InfraConfig
+	err = json.Unmarshal(rBody, &got)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	expectedInfraConfig := buildInfraCfg([]string{"foo.com:12345"})
-	if !reflect.DeepEqual(expectedInfraConfig, actualInfraConfig) {
-		t.Errorf("Unexpeced infra config. Expected:%#v, Actual:%#v", actualInfraConfig, expectedInfraConfig)
+	expected := buildInfraCfg([]string{"foo.com:12345"})
+	if diff := cmp.Diff(expected, got); diff != "" {
+		t.Errorf("status mismatch (-expected +got):\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
Before this PR, `/v1/zones/{zone}/hosts/{host}/infra_config` didn't work because of another handling rule `/v1/zones/{zone}/hosts/{host}/{hostPath:.*}`. After this patch, cloud orchestrator will be able to modify infra configs like WebRTC STUN server information by themselves again.