### PR TITLE
Fixes  http: read on closed response body error.

### DIFF
--- a/pkg/client/httputils.go
+++ b/pkg/client/httputils.go
@@ -156,6 +156,7 @@ func (rb *HTTPRequestBuilder) JSONResDoWithRetries(ret any, retryOpts RetryOptio
 	if err != nil {
 		return err
 	}
+	defer res.Body.Close()
 	return rb.parseResponse(res, ret)
 }
 
@@ -184,7 +185,6 @@ func (rb *HTTPRequestBuilder) doWithRetries(retryOpts RetryOptions) (*http.Respo
 			return nil, fmt.Errorf("error sending request: %w", err)
 		}
 	}
-	defer res.Body.Close()
 	if err := rb.helper.dumpResponse(res); err != nil {
 		return nil, err
 	}
@@ -423,6 +423,7 @@ func (w *uploadChunkWorker) upload(job uploadChunkJob) error {
 	if err != nil {
 		return err
 	}
+	defer res.Body.Close()
 	if res.StatusCode != 200 {
 		const msg = "failed uploading file chunk with status code %q. " +
 			"File %q, chunk number: %d, chunk total: %d"


### PR DESCRIPTION
- This bug was not reproducible when using a non nil Dumpster, why? When using a non nil dumpster `DumpResponse` (https://cs.opensource.google/go/go/+/refs/tags/go1.22.1:src/net/http/httputil/dump.go;l=305) was being called, `DumpResponse` consumes the body and replaces it with an io.nopCloser [ReadCloser], this way further reads were still possible.