### PR TITLE
Implement http basic account manager

### DIFF
--- a/cmd/cloud_orchestrator/main.go
+++ b/cmd/cloud_orchestrator/main.go
@@ -41,6 +41,7 @@ func LoadConfiguration() *config.Config {
 	}
 	log.Println("Main Configuration:")
 	log.Println("  Instance Manager Type: " + config.InstanceManager.Type)
+	log.Println("  Account Manager Type: " + config.AccountManager.Type)
 	if config.InstanceManager.Type == instances.GCEIMType {
 		log.Println("  GCP Project: " + config.InstanceManager.GCP.ProjectID)
 	}
@@ -114,6 +115,8 @@ func LoadAccountManager(config *config.Config) accounts.Manager {
 		am = accounts.NewGAEUsersAccountManager()
 	case accounts.UnixAMType:
 		am = accounts.NewUnixAccountManager()
+	case accounts.HTTPBasicAMType:
+		am = accounts.NewHTTPBasicAccountManager()
 	default:
 		log.Fatal("Unknown Account Manager type: ", config.AccountManager.Type)
 	}

--- a/pkg/app/accounts/basic.go
+++ b/pkg/app/accounts/basic.go
@@ -1,0 +1,72 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package accounts
+
+import (
+	"net/http"
+
+	apperr "github.com/google/cloud-android-orchestration/pkg/app/errors"
+	appOAuth2 "github.com/google/cloud-android-orchestration/pkg/app/oauth2"
+)
+
+const HTTPBasicAMType AMType = "http-basic"
+
+// Implements the AccountManager interfaces using the RFC 2617 HTTP Basic
+// Authentication, where the user-ID and password are provided in the HTTP
+// request header.
+type HTTPBasicAccountManager struct{}
+
+func NewHTTPBasicAccountManager() *HTTPBasicAccountManager {
+	return &HTTPBasicAccountManager{}
+}
+
+func (m *HTTPBasicAccountManager) UserFromRequest(r *http.Request) (User, error) {
+	return userFromRequest(r)
+}
+
+func (m *HTTPBasicAccountManager) OnOAuth2Exchange(w http.ResponseWriter, r *http.Request, tk appOAuth2.IDTokenClaims) (User, error) {
+	rUser, err := userFromRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	user, ok := tk["user"]
+	if !ok {
+		return nil, apperr.NewForbiddenError("no user in id token", nil)
+	}
+	tkUser, ok := user.(string)
+	if !ok {
+		return nil, apperr.NewForbiddenError("malformed user in id token", nil)
+	}
+	if rUser.Username() != tkUser {
+		return nil, apperr.NewForbiddenError("logged in user doesn't match oauth2 user", nil)
+	}
+	return rUser, nil
+}
+
+type HTTPBasicUser struct {
+	username string
+}
+
+func (u *HTTPBasicUser) Username() string {
+	return u.username
+}
+
+func userFromRequest(r *http.Request) (*HTTPBasicUser, error) {
+	username, _, ok := r.BasicAuth()
+	if !ok {
+		return nil, apperr.NewBadRequestError("No username in request", nil)
+	}
+	return &HTTPBasicUser{username}, nil
+}

--- a/pkg/app/errors/errors.go
+++ b/pkg/app/errors/errors.go
@@ -68,6 +68,10 @@ func NewUnauthenticatedError(msg string, e error) error {
 	return &AppError{Msg: msg, StatusCode: http.StatusUnauthorized, Err: e}
 }
 
+func NewForbiddenError(msg string, e error) error {
+	return &AppError{Msg: msg, StatusCode: http.StatusForbidden, Err: e}
+}
+
 func NewServiceUnavailableError(msg string, e error) error {
 	return &AppError{Msg: msg, StatusCode: http.StatusServiceUnavailable, Err: e}
 }


### PR DESCRIPTION
This PR includes two commits:

- The first commit creates a BasicAccountManager which follows the HTTP Basic Authentication to get the username from a HTTP request.
- The second commit labels the owner of the created docker container based on the user from BasicAccountManager.