### PR TITLE
Change HostOut path for ARM64 during cvdr create

### DIFF
--- a/pkg/cli/cvd_test.go
+++ b/pkg/cli/cvd_test.go
@@ -71,3 +71,27 @@ func TestAdditionalInstancesNum(t *testing.T) {
 		}
 	}
 }
+
+func TestGetHostOutRelativePathSucceeds(t *testing.T) {
+	targetArch := "x86_64"
+
+	got, err := GetHostOutRelativePath(targetArch)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := "out/host/linux-x86"
+	if diff := cmp.Diff(expected, got); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestGetHostOutRelativePathFailsUnknownTargetArch(t *testing.T) {
+	targetArch := "unknown"
+
+	_, err := GetHostOutRelativePath(targetArch)
+
+	if err == nil {
+		t.Errorf("expected error")
+	}
+}


### PR DESCRIPTION
After running `lunch`, ANDROID_HOST_OUT is set as `$ANDROID_BUILD_TOP/out/host/linux-x86`. To be run in ARM64 dockerized instance, we should send `cvd-host_package.tar.gz` for ARM64.