### PR TITLE
Implement http basic auth for cvdr.

### DIFF
--- a/pkg/cli/config.go
+++ b/pkg/cli/config.go
@@ -36,11 +36,20 @@ type HostConfig struct {
 }
 
 type AuthnConfig struct {
-	OIDCToken *OIDCTokenConfig `json:"oidc_token,omitempty"`
+	OIDCToken      *OIDCTokenConfig      `json:"oidc_token,omitempty"`
+	HTTPBasicAuthn *HTTPBasicAuthnConfig `json:"http_basic_authn,omitempty"`
 }
 
 type OIDCTokenConfig struct {
 	TokenFile string `json:"token_file,omitempty"`
+}
+
+type UsernameSrcType string
+
+const UnixUsernameSrc UsernameSrcType = "unix"
+
+type HTTPBasicAuthnConfig struct {
+	UsernameSrc UsernameSrcType `json:"username_src,omitempty"`
 }
 
 type Config struct {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -55,10 +55,15 @@ func (e *ApiCallError) Is(target error) bool {
 
 type AuthnOpts struct {
 	OIDCToken *OIDCToken
+	HTTPBasic *HTTPBasic
 }
 
 type OIDCToken struct {
 	Value string
+}
+
+type HTTPBasic struct {
+	Username string
 }
 
 type ServiceOptions struct {
@@ -104,8 +109,13 @@ func NewService(opts *ServiceOptions) (Service, error) {
 		}
 		helper.Client.Transport = &http.Transport{Proxy: http.ProxyURL(proxyUrl)}
 	}
-	if opts.Authn != nil && opts.Authn.OIDCToken != nil {
-		helper.AccessToken = opts.Authn.OIDCToken.Value
+	if opts.Authn != nil {
+		if opts.Authn.OIDCToken != nil {
+			helper.AccessToken = opts.Authn.OIDCToken.Value
+		}
+		if opts.Authn.HTTPBasic != nil {
+			helper.HTTPBasicUsername = opts.Authn.HTTPBasic.Username
+		}
 	}
 	return &serviceImpl{ServiceOptions: opts, httpHelper: helper}, nil
 }


### PR DESCRIPTION
Always permit users to access the homepage and the cloud_orchestrator config without specifying their username. Users can get the account manager type accordingly to decide whether they should set their username in following HTTP requests. 