### PR TITLE
(wip) enable cvdr connection in docker

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -253,7 +253,7 @@ func TestBuildAgentCmdline(t *testing.T) {
 		skipConfirmation: false,
 	}
 	device := "device"
-	args := buildAgentCmdArgs(&flags, device)
+	args := buildAgentCmdArgs(&flags, device, true)
 	var options CommandOptions
 	cmd := NewCVDRemoteCommand(&options)
 	subCmd, args, err := cmd.command.Traverse(args)
@@ -266,8 +266,8 @@ func TestBuildAgentCmdline(t *testing.T) {
 	if reflect.DeepEqual(args, []string{device}) {
 		t.Errorf("expected resulting args to just have [%q], but found %v", device, args)
 	}
-	if subCmd.Name() != ConnectionAgentCommandName {
-		t.Errorf("expected it to parse %q command, found: %q", ConnectionAgentCommandName, subCmd.Name())
+	if subCmd.Name() != ConnectionWebrtcAgentCommandName {
+		t.Errorf("expected it to parse %q command, found: %q", ConnectionWebrtcAgentCommandName, subCmd.Name())
 	}
 	// TODO(jemoreira): Compare the parsed flags with used flags
 }


### PR DESCRIPTION
FYI, this PR is not ready to be merged, just for sharing prototype.

With this PR, we can start cvdr connect, w/o webrtc connection.

```
$ ./cvdr \
--http_proxy=socks5://localhost:1337 \
--service_url=http://100.114.242.57:8080 \
--zone=local \
--host=$CO_HOST_NAME \
connect cvd-1
$ adb connect <socket_path>
```

Cons of this PR:
- This code has so many hard-coded values, like IP address & port of docker instance.
- Currently termination of `runConnectionBaseAgentCommand` is blocked, so disconnecting adb connection is executed by sending SIGINT(Ctrl+C) from the shell executing `cvdr connect`.