### PR TITLE
Expose IP Address of docker instance via ListHosts

### DIFF
--- a/api/v1/instancemanager.go
+++ b/api/v1/instancemanager.go
@@ -23,6 +23,8 @@ type HostInstance struct {
 type DockerInstance struct {
 	// Specifies the docker image name.
 	ImageName string `json:"image_name"`
+	// IP address of docker instance.
+	IPAddress string `json:"ip_address"`
 }
 
 type GCPInstance struct {


### PR DESCRIPTION
With this PR, in `GET /v1/zones/local/hosts`,

```
{
  "items": [
    {
      "name": "3b035d58d90d22ecf97c735640567ad81528e5e9fbce38b24a44349214527d9f",
      "docker": {
        "image_name": "cuttlefish:latest",
        "ip_address": "172.17.0.2"
      }
    }
  ]
}
```

We can get IP address information of docker instance. I'm having a plan to use this information by `cvdr connect`.