### PR TITLE
Introduce --connect_agent with the new type(proxy_agent) into cvdr connect

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.2.0
 	github.com/docker/docker v24.0.9+incompatible
 	github.com/golang-jwt/jwt v3.2.2+incompatible
-	github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20231215232042-8c95f6b070a9
+	github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20240502215314-3182038fb7ea
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -103,6 +103,10 @@ github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20231215232042-8c95f6b070a9 h1:RR8hSPf8yGLh5ELz5kkpWuCek2Afg9cTbYTBYKXy1/o=
 github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20231215232042-8c95f6b070a9/go.mod h1:MQWsd4UGUI1qNTTvDaD1vi5f6oxUDgggUELH3UpBdhY=
+github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20240425064852-f3844134cf1c h1:tkR8hPB2xe8a5VVxDPWvOa98thyA98AnimWXlyrfuRg=
+github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20240425064852-f3844134cf1c/go.mod h1:MQWsd4UGUI1qNTTvDaD1vi5f6oxUDgggUELH3UpBdhY=
+github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20240502215314-3182038fb7ea h1:5ph/60ouIJj+YvXVeob5FU8rPCyjzWgjb8+x7k9QcKU=
+github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20240502215314-3182038fb7ea/go.mod h1:MQWsd4UGUI1qNTTvDaD1vi5f6oxUDgggUELH3UpBdhY=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=

--- a/pkg/cli/adbserver.go
+++ b/pkg/cli/adbserver.go
@@ -21,23 +21,39 @@ import (
 
 type ADBServerProxy interface {
 	Connect(port int) error
+	ConnectWithLocalFileSystem(path string) error
 	Disconnect(port int) error
+	DisconnectWithLocalFileSystem(path string) error
 }
 
 const ADBServerPort = 5037
 
 type ADBServerProxyImpl struct{}
 
-func (p *ADBServerProxyImpl) Connect(port int) error {
-	adbSerial := fmt.Sprintf("127.0.0.1:%d", port)
+func (p *ADBServerProxyImpl) connect(adbSerial string) error {
 	msg := fmt.Sprintf("host:connect:%s", adbSerial)
 	return p.sendMsg(msg)
 }
 
-func (p *ADBServerProxyImpl) Disconnect(port int) error {
-	adbSerial := fmt.Sprintf("127.0.0.1:%d", port)
+func (p *ADBServerProxyImpl) Connect(port int) error {
+	return p.connect(fmt.Sprintf("127.0.0.1:%d", port))
+}
+
+func (p *ADBServerProxyImpl) ConnectWithLocalFileSystem(path string) error {
+	return p.connect(fmt.Sprintf("localfilesystem:%s", path))
+}
+
+func (p *ADBServerProxyImpl) disconnect(adbSerial string) error {
 	msg := fmt.Sprintf("host:disconnect:%s", adbSerial)
 	return p.sendMsg(msg)
+}
+
+func (p *ADBServerProxyImpl) Disconnect(port int) error {
+	return p.disconnect(fmt.Sprintf("127.0.0.1:%d", port))
+}
+
+func (p *ADBServerProxyImpl) DisconnectWithLocalFileSystem(path string) error {
+	return p.disconnect(fmt.Sprintf("localfilesystem:%s", path))
 }
 
 func (*ADBServerProxyImpl) sendMsg(msg string) error {

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -83,7 +83,15 @@ func (*fakeADBServerProxy) Connect(int) error {
 	return nil
 }
 
+func (*fakeADBServerProxy) ConnectWithLocalFileSystem(string) error {
+	return nil
+}
+
 func (*fakeADBServerProxy) Disconnect(int) error {
+	return nil
+}
+
+func (*fakeADBServerProxy) DisconnectWithLocalFileSystem(string) error {
 	return nil
 }
 
@@ -253,7 +261,7 @@ func TestBuildAgentCmdline(t *testing.T) {
 		skipConfirmation: false,
 	}
 	device := "device"
-	args := buildAgentCmdArgs(&flags, device)
+	args := buildAgentCmdArgs(&flags, device, ConnectionWebRTCAgentCommandName)
 	var options CommandOptions
 	cmd := NewCVDRemoteCommand(&options)
 	subCmd, args, err := cmd.command.Traverse(args)
@@ -266,8 +274,8 @@ func TestBuildAgentCmdline(t *testing.T) {
 	if reflect.DeepEqual(args, []string{device}) {
 		t.Errorf("expected resulting args to just have [%q], but found %v", device, args)
 	}
-	if subCmd.Name() != ConnectionAgentCommandName {
-		t.Errorf("expected it to parse %q command, found: %q", ConnectionAgentCommandName, subCmd.Name())
+	if subCmd.Name() != ConnectionWebRTCAgentCommandName {
+		t.Errorf("expected it to parse %q command, found: %q", ConnectionWebRTCAgentCommandName, subCmd.Name())
 	}
 	// TODO(jemoreira): Compare the parsed flags with used flags
 }

--- a/pkg/cli/conn.go
+++ b/pkg/cli/conn.go
@@ -22,6 +22,7 @@ import (
 	"log"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -61,6 +62,10 @@ func EnsureConnDirsExist(controlDir string) error {
 	logsDir := logsDir(controlDir)
 	if err := os.MkdirAll(logsDir, 0755); err != nil {
 		return fmt.Errorf("failed to create logs directory: %w", err)
+	}
+	proxyDir := proxyDir(controlDir)
+	if err := os.MkdirAll(proxyDir, 0755); err != nil {
+		return fmt.Errorf("failed to create proxy directory: %w", err)
 	}
 	return nil
 }
@@ -548,7 +553,21 @@ func createControlSocket(dir, name string) (*net.UnixListener, error) {
 }
 
 func logsDir(controlDir string) string {
-	return controlDir + "/logs"
+	return filepath.Join(controlDir, "logs")
+}
+
+func proxyDir(controlDir string) string {
+	return filepath.Join(controlDir, "proxy")
+}
+
+func GetProxySocketPath(controlDir, host, device string) string {
+	proxyDir := proxyDir(controlDir)
+	shortenHost := host
+	if len(shortenHost) >= 8 {
+		shortenHost = shortenHost[:8]
+	}
+	socketName := strings.Join([]string{shortenHost, device}, "_") + ".sock"
+	return filepath.Join(proxyDir, socketName)
 }
 
 func createLogger(controlDir string, dev RemoteCVDLocator) (*log.Logger, error) {

--- a/pkg/cli/host.go
+++ b/pkg/cli/host.go
@@ -15,6 +15,8 @@
 package cli
 
 import (
+	"fmt"
+
 	apiv1 "github.com/google/cloud-android-orchestration/api/v1"
 	"github.com/google/cloud-android-orchestration/pkg/client"
 )
@@ -50,4 +52,17 @@ func hostnames(service client.Service) ([]string, error) {
 		result = append(result, h.Name)
 	}
 	return result, nil
+}
+
+func findHost(service client.Service, name string) (*apiv1.HostInstance, error) {
+	hosts, err := service.ListHosts()
+	if err != nil {
+		return nil, fmt.Errorf("error listing hosts: %w", err)
+	}
+	for _, host := range hosts.Items {
+		if host.Name == name {
+			return host, nil
+		}
+	}
+	return nil, fmt.Errorf("name not found: %s", name)
 }


### PR DESCRIPTION
How to turn on `--connect_agent` flag with `proxy_agent` in `cvdr connect`:

```
./cvdr \
--http_proxy=socks5://localhost:1337 \
--service_url=http://100.114.242.57:8080 \
--zone=local \
--host=$CO_HOST_NAME \
--connect_agent=proxy_agent \
connect
```

Currently this PR needs some fixes:
- Agent process should be terminated(Make it being daemonized): WIP