### PR TITLE
Add /username endpoint for UsernameOnlyAccountManager to log username.

### DIFF
--- a/pkg/app/accounts/usernameonly.go
+++ b/pkg/app/accounts/usernameonly.go
@@ -15,16 +15,23 @@
 package accounts
 
 import (
+	"html/template"
 	"net/http"
+	"strings"
 
 	apperr "github.com/google/cloud-android-orchestration/pkg/app/errors"
 )
 
-const UsernameOnlyAMType AMType = "username-only"
+const (
+	UsernameOnlyAMType AMType = "username-only"
+
+	unameCookie = "accountUsername"
+)
 
 // Implements the AccountManager interfaces for closed deployed cloud
-// orchestrators. This AccountManager leverages the RFC 2617 HTTP Basic
-// Authentication to get the account information, but only username is used.
+// orchestrators. This AccountManager first gets the account information from
+// HTTP cookies, and leverages the RFC 2617 HTTP Basic Authentication if the
+// cookie does not present. Note that only username is used for both cases.
 type UsernameOnlyAccountManager struct{}
 
 func NewUsernameOnlyAccountManager() *UsernameOnlyAccountManager {
@@ -44,9 +51,65 @@ func (u *UsernameOnlyUser) Username() string { return u.username }
 func (u *UsernameOnlyUser) Email() string { return "" }
 
 func userFromRequest(r *http.Request) (*UsernameOnlyUser, error) {
+	// Accept putting the username in a cookie to support using a browser
+	// to interact with CO.
+	cookie, err := r.Cookie(unameCookie)
+	if err == nil && cookie.Value != "" {
+		return &UsernameOnlyUser{cookie.Value}, nil
+	}
 	username, _, ok := r.BasicAuth()
 	if !ok {
 		return nil, apperr.NewBadRequestError("No username in request", nil)
 	}
 	return &UsernameOnlyUser{username}, nil
+}
+
+type LoggingData struct {
+	Username string
+	Error    string
+}
+
+var loggingTemplate = template.Must(template.New("logging").Parse(`
+<!DOCTYPE html>
+<html>
+<head><title>AM Logging</title></head>
+<body>
+    {{if .Error}}
+        <p style="color: red; font-size:2vw;">{{.Error}}</p>
+    {{end}}
+    {{if .Username}}
+        <h2> UsernameOnly account manager</h2>
+        <p style="font-size:3vw;">Welcome {{.Username}}!</p>
+        <p style="font-size:2vw;">You can now visit other pages.</p>
+    {{else}}
+        <form method="POST">
+            <h2> Logging username for UsernameOnly account manager</h2>
+            <label for="uname">username:</label>
+            <input type="text" id="uname" name="username" required><br><br>
+            <input type="submit" value="Submit">
+        </form>
+    {{end}}
+</body>
+</html>
+`))
+
+func UsernameOnlyLoggingForm(w http.ResponseWriter, r *http.Request) error {
+	return loggingTemplate.Execute(w, nil)
+}
+
+func HandleUsernameOnlyLogging(w http.ResponseWriter, r *http.Request) error {
+	username := r.FormValue("username")
+	if strings.TrimSpace(username) == "" {
+		return loggingTemplate.Execute(w, LoggingData{
+			Error: "Please enter a valid username",
+		})
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:  unameCookie,
+		Value: username,
+		Path:  "/",
+	})
+	return loggingTemplate.Execute(w, LoggingData{
+		Username: username,
+	})
 }


### PR DESCRIPTION
- To customize the user input when using a browser to interact with cloud_orchestrator.