### PR TITLE
Introduce url query account manager.

### DIFF
--- a/cmd/cloud_orchestrator/main.go
+++ b/cmd/cloud_orchestrator/main.go
@@ -117,6 +117,8 @@ func LoadAccountManager(config *config.Config) accounts.Manager {
 		am = accounts.NewUnixAccountManager()
 	case accounts.HTTPBasicAMType:
 		am = accounts.NewHTTPBasicAccountManager()
+	case accounts.URLQueryAMType:
+		am = accounts.NewURLQueryAccountManager()
 	default:
 		log.Fatal("Unknown Account Manager type: ", config.AccountManager.Type)
 	}

--- a/pkg/app/accounts/urlquery.go
+++ b/pkg/app/accounts/urlquery.go
@@ -1,0 +1,51 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package accounts
+
+import (
+	"net/http"
+
+	apperr "github.com/google/cloud-android-orchestration/pkg/app/errors"
+)
+
+const (
+	URLQueryAMType AMType = "url-query"
+
+	URLQueryKey = "user"
+)
+
+// Implements the AccountManager interfaces using a URL query parameter to hint
+// the account username. For example, `?user=<username>`.
+type URLQueryAccountManager struct{}
+
+func NewURLQueryAccountManager() *URLQueryAccountManager {
+	return &URLQueryAccountManager{}
+}
+
+func (m *URLQueryAccountManager) UserFromRequest(r *http.Request) (User, error) {
+	username := r.URL.Query().Get(URLQueryKey)
+	if username == "" {
+		return nil, apperr.NewBadRequestError("no username in url query", nil)
+	}
+	return &URLQueryUser{username}, nil
+}
+
+type URLQueryUser struct {
+	username string
+}
+
+func (u *URLQueryUser) Username() string { return u.username }
+
+func (u *URLQueryUser) Email() string { return "" }


### PR DESCRIPTION
- URLQueryAccountManager gets the account username from a URL query parameter: `?user=<username>`.

Tests:
- `curl -k -d '{}' --request POST http://localhost:8080/v1/zones/local/hosts?user=<username>`
- `curl -k --request GET http://localhost:8080/v1/zones/local/hosts?user=<username>`
- `curl -k -d '{}' --request DELETE http://localhost:8080/v1/zones/local/hosts/<host_name>?user=<username>`