### PR TITLE
Write documentation about definition of Cloud Orchestrator and cvdr.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,14 @@ devices in the cloud.
 The application is developed for and tested on Google Cloud Platform, but it's
 designed in a way that should allow its deployment in other Cloud solutions
 without much trouble.
+
+## Links for each component
+
+To know details, please refer to these documents below.
+
+- [Cloud Orchestrator](docs/cloud_orchestrator.md): A web service for hosting
+VMs or containers for running Cuttlefish instances on top of.
+- [cvdr](docs/cvdr.md): CLI wrapper of Cloud Orchestrator providing
+user-friendly interface.
+- [Cuttlefish Web Launcher](web/page0/README.md): Navigator & web-based wrapper
+of Cloud Orchestrator providing user-friendly interface.

--- a/docs/cloud_orchestrator.md
+++ b/docs/cloud_orchestrator.md
@@ -1,0 +1,17 @@
+# Cloud Orchestrator
+
+This page describes about `Cloud Orchestrator`.
+
+## What's Cloud Orchestrator?
+
+Cloud Orchestrator is a web service that managing virtual machines or containers
+as host instances.
+It can create, list, and delete host instances, and provides the way to access
+hosts to launch Cuttlefish instances on top of the host instance via Host
+Orchestrator.
+
+## Use Cloud Orchestrator
+
+We're currently providing using Cloud Orchestrator with Docker instances as
+hosts. Please read [docker.md](docker.md) to follow.
+<!-- TODO(ser-io): Write how to use CO for GCP. -->

--- a/docs/cvdr.md
+++ b/docs/cvdr.md
@@ -1,6 +1,13 @@
-# Use cvdr from your local machine
+# cvdr
 
-This page describes how to run `cvdr` to use cloud orchestrator remotely.
+This page describes about `cvdr` and its usage.
+
+## What's cvdr?
+
+`cvdr` is a CLI binary tool for accessing and managing Cuttlefish instances
+remotely.
+It wraps [Cloud Orchestrator](cloud_orchestrator.md), to provide user-friendly
+interface.
 
 ## Build cvdr
 
@@ -13,9 +20,9 @@ go build ./cmd/cvdr
 
 ## Find URL of cloud orchestrator
 
-If cloud orchestrator manages docker instances, please read
-[docker.md](docker.md) to check URL of cloud orchestrator.
-Let's define this URL as `SERVICE_URL` for the rest of this page.
+Please read [cloud_orchestrator.md](cloud_orchestrator.md) to know.
+Let's define the URL of Cloud Orchestrator as `SERVICE_URL` for the rest of this
+page.
 
 ## Use cvdr step-by-step
 


### PR DESCRIPTION
To write a new document under [source.android.com](https://source.android.com/), we need a document to define what's Cloud Orchestrator and cvdr. I thought here's the better place than [source.android.com](https://source.android.com/).

CWL(Cuttlefish Web Launcher, Page 0) is not scope of this PR for providing detail in public.