### PR TITLE
Add `CreateCVDOp` method to host orchestrator service client.

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -142,6 +142,10 @@ func (fakeHostService) CreateCVD(req *hoapi.CreateCVDRequest, creds string) (*ho
 	return &hoapi.CreateCVDResponse{CVDs: []*hoapi.CVD{{Name: "cvd-1"}}}, nil
 }
 
+func (fakeHostService) CreateCVDOp(req *hoapi.CreateCVDRequest, creds string) (*hoapi.Operation, error) {
+	return nil, nil
+}
+
 func (fakeHostService) DeleteCVD(id string) error {
 	return nil
 }

--- a/pkg/client/host_orchestrator_client.go
+++ b/pkg/client/host_orchestrator_client.go
@@ -47,6 +47,7 @@ type HostOrchestratorService interface {
 	// Create a new device with artifacts from the build server or previously uploaded by the user.
 	// If not empty, the provided credentials will be used to download necessary artifacts from the build api.
 	CreateCVD(req *hoapi.CreateCVDRequest, buildAPICredentials string) (*hoapi.CreateCVDResponse, error)
+	CreateCVDOp(req *hoapi.CreateCVDRequest, buildAPICredentials string) (*hoapi.Operation, error)
 
 	// Deletes an existing cvd instance.
 	DeleteCVD(id string) error
@@ -249,13 +250,21 @@ func (c *HostOrchestratorServiceImpl) FetchArtifacts(req *hoapi.FetchArtifactsRe
 	return res, nil
 }
 
-func (c *HostOrchestratorServiceImpl) CreateCVD(req *hoapi.CreateCVDRequest, creds string) (*hoapi.CreateCVDResponse, error) {
-	var op hoapi.Operation
+func (c *HostOrchestratorServiceImpl) CreateCVDOp(req *hoapi.CreateCVDRequest, creds string) (*hoapi.Operation, error) {
+	op := &hoapi.Operation{}
 	rb := c.HTTPHelper.NewPostRequest("/cvds", req)
 	if creds != "" {
 		rb.AddHeader(c.BuildAPICredentialsHeader, creds)
 	}
-	if err := rb.JSONResDo(&op); err != nil {
+	if err := rb.JSONResDo(op); err != nil {
+		return nil, err
+	}
+	return op, nil
+}
+
+func (c *HostOrchestratorServiceImpl) CreateCVD(req *hoapi.CreateCVDRequest, creds string) (*hoapi.CreateCVDResponse, error) {
+	op, err := c.CreateCVDOp(req, creds)
+	if err != nil {
 		return nil, err
 	}
 	res := &hoapi.CreateCVDResponse{}


### PR DESCRIPTION
- The new method allows the client to implement their own waiting logic.