### PR TITLE
feat: make network and subnetwork configurable

### DIFF
--- a/pkg/app/instances/gce.go
+++ b/pkg/app/instances/gce.go
@@ -36,6 +36,8 @@ type GCPIMConfig struct {
 	ProjectID            string
 	HostImageFamily      string
 	HostOrchestratorPort int
+	Network              string
+	Subnetwork           string
 	// If true, instances created should be compatible with `acloud CLI`.
 	AcloudCompatible bool
 }
@@ -124,7 +126,8 @@ func (m *GCEInstanceManager) CreateHost(zone string, req *apiv1.CreateHostReques
 		},
 		NetworkInterfaces: []*compute.NetworkInterface{
 			{
-				Name: buildDefaultNetworkName(m.Config.GCP.ProjectID),
+				Network:    m.Config.GCP.Network,
+				Subnetwork: m.Config.GCP.Subnetwork,
 				AccessConfigs: []*compute.AccessConfig{
 					{
 						Name: "External NAT",
@@ -271,10 +274,6 @@ func validateRequest(r *apiv1.CreateHostRequest) error {
 		return errors.NewBadRequestError("invalid CreateHostRequest", nil)
 	}
 	return nil
-}
-
-func buildDefaultNetworkName(projectID string) string {
-	return fmt.Sprintf("projects/%s/global/networks/default", projectID)
 }
 
 func BuildHostInstance(in *compute.Instance) (*apiv1.HostInstance, error) {

--- a/pkg/app/instances/gce_test.go
+++ b/pkg/app/instances/gce_test.go
@@ -40,6 +40,8 @@ var testConfig = Config{
 	GCP: &GCPIMConfig{
 		ProjectID:       "google.com:test-project",
 		HostImageFamily: "projects/test-project-releases/global/images/family/foo",
+		Network:         "projects/google.com:test-project/global/networks/default",
+		Subnetwork:      "",
 	},
 }
 
@@ -171,7 +173,7 @@ func TestCreateHostRequestBody(t *testing.T) {
           "type": "ONE_TO_ONE_NAT"
         }
       ],
-      "name": "projects/google.com:test-project/global/networks/default"
+      "network": "projects/google.com:test-project/global/networks/default"
     }
   ]
 }`

--- a/scripts/gcp/app/conf.toml.tmpl
+++ b/scripts/gcp/app/conf.toml.tmpl
@@ -45,6 +45,8 @@ AllowSelfSignedHostSSLCertificate = true
 ProjectID = "${PROJECT_ID}"
 HostImageFamily = "projects/${PROJECT_ID}/global/images/family/cf-debian11-amd64"
 HostOrchestratorPort = 2443
+Network = "projects/${PROJECT_ID}/global/networks/default"
+Subnetwork = ""
 
 [WebRTC]
 STUNServers = ["stun:stun.l.google.com:19302"]


### PR DESCRIPTION
This PR makes `network` and `subnetwork` configurable via the `conf.toml` if GCP is used to deploy instances.  At the moment it is statically set in the `cloud-orchestrator` but we could also make this configurable on a `cvdr host create` request basis.