### PR TITLE
Websocket

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,12 +14,14 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
+	github.com/gorilla/websocket v1.5.3
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/pelletier/go-toml v1.9.5
 	github.com/pion/logging v0.2.2
 	github.com/pion/webrtc/v3 v3.1.47
 	github.com/sergi/go-diff v1.2.0
 	github.com/spf13/cobra v1.6.1
+	golang.org/x/net v0.23.0
 	golang.org/x/oauth2 v0.8.0
 	golang.org/x/term v0.18.0
 	google.golang.org/api v0.118.0
@@ -75,7 +77,6 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/crypto v0.21.0 // indirect
-	golang.org/x/net v0.23.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -127,6 +127,8 @@ github.com/googleapis/gax-go/v2 v2.8.0 h1:UBtEZqx1bjXtOQ5BVTkuYghXrr3N4V123VKJK6
 github.com/googleapis/gax-go/v2 v2.8.0/go.mod h1:4orTrqY6hXxxaUL4LHIPl6lGo8vAE38/qKbhSAKP6QI=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -1251,13 +1251,13 @@ func runConnectionWebSocketAgentCommand(flags *ConnectFlags, c *command, args []
 	wsRoot = strings.ReplaceAll(wsRoot, "https://", "wss://")
 	wsRoot = strings.ReplaceAll(wsRoot, "http://", "ws://")
 	if strings.HasSuffix(wsRoot, "/") {
-		wsRoot = wsRoot[:len(wsRoot) - 1]
+		wsRoot = wsRoot[:len(wsRoot)-1]
 	}
 
 	// Connect to ADB proxy WebSocket
 	//   wss://127.0.0.1:1443/devices/cvd-1/adb
 	// Since the operator is self-signed, skip verifying cert
-	dialer := websocket.Dialer {
+	dialer := websocket.Dialer{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
 		},
@@ -1292,9 +1292,9 @@ func runConnectionWebSocketAgentCommand(flags *ConnectFlags, c *command, args []
 	defer tcpConn.Close()
 
 	// Send connect result to the parent
-	result := ConnStatus {
-		ADB: ForwarderState {
-			Port: adbPort,
+	result := ConnStatus{
+		ADB: ForwarderState{
+			Port:  adbPort,
 			State: StateAsStr(FwdConnected),
 		},
 	}
@@ -1319,8 +1319,8 @@ func runConnectionWebSocketAgentCommand(flags *ConnectFlags, c *command, args []
 	// Redirect WebSocket to ADB TCP port
 	wsWrapper := &wsIoWrapper{
 		wsConn: wsConn,
-		pos: 0,
-		buf: nil,
+		pos:    0,
+		buf:    nil,
 	}
 	go func() {
 		io.Copy(wsWrapper, tcpConn)
@@ -1334,8 +1334,8 @@ func runConnectionWebSocketAgentCommand(flags *ConnectFlags, c *command, args []
 // Wrapper for implementing io.ReadWriteCloser of websocket.Conn
 type wsIoWrapper struct {
 	wsConn *websocket.Conn
-	pos int
-	buf []byte
+	pos    int
+	buf    []byte
 }
 
 var _ io.ReadWriteCloser = (*wsIoWrapper)(nil)

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -1277,10 +1277,11 @@ func runConnectionWebSocketAgentCommand(flags *ConnectFlags, c *command, args []
 		return err
 	}
 	adbPort := l.Addr().(*net.TCPAddr).Port
-	if err := opts.ADBServerProxy.Connect(adbPort); err != nil {
-		c.PrintErrf("Failed to connect ADB to device: %v\n", err)
-		return err
-	}
+	go func() {
+		if err := opts.ADBServerProxy.Connect(adbPort); err != nil {
+			c.PrintErrf("Failed to connect ADB to device: %v\n", err)
+		}
+	}()
 	tcpConn, err := l.Accept()
 	if err != nil {
 		c.PrintErrf("Failed to accept ADB socket: %v", err)

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -1321,10 +1321,9 @@ func runConnectionWebSocketAgentCommand(flags *ConnectFlags, c *command, args []
 		pos:    0,
 		buf:    nil,
 	}
-	defer wsWrapper.Close()
 	go func() {
+		defer wsWrapper.Close()
 		io.Copy(wsWrapper, tcpConn)
-		wsWrapper.Close()
 	}()
 	io.Copy(tcpConn, wsWrapper)
 	return nil

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -1250,7 +1250,9 @@ func runConnectionWebSocketAgentCommand(flags *ConnectFlags, c *command, args []
 	wsRoot := flags.ServiceURL
 	wsRoot = strings.ReplaceAll(wsRoot, "https://", "wss://")
 	wsRoot = strings.ReplaceAll(wsRoot, "http://", "ws://")
-	wsRoot, _ = strings.CutSuffix(wsRoot, "/")
+	if strings.HasSuffix(wsRoot, "/") {
+		wsRoot = wsRoot[:len(wsRoot) - 1]
+	}
 
 	// Connect to ADB proxy WebSocket
 	//   wss://127.0.0.1:1443/devices/cvd-1/adb

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -1321,9 +1321,10 @@ func runConnectionWebSocketAgentCommand(flags *ConnectFlags, c *command, args []
 		pos:    0,
 		buf:    nil,
 	}
+	defer wsWrapper.Close()
 	go func() {
-		defer wsWrapper.Close()
 		io.Copy(wsWrapper, tcpConn)
+		wsWrapper.Close()
 	}()
 	io.Copy(tcpConn, wsWrapper)
 	return nil


### PR DESCRIPTION
Add websocket_agent for `cvdr connect`

After https://github.com/google/android-cuttlefish/pull/606 is merged, it is able to access adb via WebSocket endpoint.

Add cvdr connect agent for that endpoint.

The command would be

```
./cvdr connect --connect_agent=websocket_agent --service_url=https://127.0.0.1:1443 --host=websocket cvd-1 
```

to connect ADB via host orchestrator's WebSocket endpoint.