### PR TITLE
Enable UsernameOnlyAccountManager to support OAuth

### DIFF
--- a/pkg/app/accounts/usernameonly.go
+++ b/pkg/app/accounts/usernameonly.go
@@ -26,6 +26,8 @@ const (
 
 	unameCookie    = "accountUsername"
 	userMailCookie = "accountEmail"
+
+	UserEmailHeaderKey = "X-UserAccount-Email"
 )
 
 // Implements the AccountManager interfaces for closed deployed cloud
@@ -61,7 +63,8 @@ func (m *UsernameOnlyAccountManager) UserFromRequest(r *http.Request) (User, err
 	if !ok {
 		return nil, nil
 	}
-	return &UsernameOnlyUser{username, ""}, nil
+	email = r.Header.Get(UserEmailHeaderKey)
+	return &UsernameOnlyUser{username, email}, nil
 }
 
 type UsernameOnlyUser struct {

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -1587,6 +1587,7 @@ func buildServiceBuilder(builder client.ServiceBuilder, config *Config) serviceB
 					}
 					opts.Authn.HTTPBasic = &client.HTTPBasic{
 						Username: user.Username,
+						Email:    authnConfig.HTTPBasicAuthn.UserEmail,
 					}
 				default:
 					return nil, fmt.Errorf("invalid http basic authn UsernameSrc type: %s", authnConfig.HTTPBasicAuthn.UsernameSrc)

--- a/pkg/cli/config.go
+++ b/pkg/cli/config.go
@@ -50,6 +50,7 @@ const UnixUsernameSrc UsernameSrcType = "unix"
 
 type HTTPBasicAuthnConfig struct {
 	UsernameSrc UsernameSrcType `json:"username_src,omitempty"`
+	UserEmail   string          `json:"user_email,omitempty"`
 }
 
 type Config struct {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -64,6 +64,7 @@ type OIDCToken struct {
 
 type HTTPBasic struct {
 	Username string
+	Email    string
 }
 
 type ServiceOptions struct {
@@ -113,6 +114,7 @@ func NewService(opts *ServiceOptions) (Service, error) {
 		}
 		if opts.Authn.HTTPBasic != nil {
 			helper.HTTPBasicUsername = opts.Authn.HTTPBasic.Username
+			helper.HTTPBasicEmail = opts.Authn.HTTPBasic.Email
 		}
 	}
 	return &serviceImpl{ServiceOptions: opts, httpHelper: helper}, nil

--- a/pkg/client/httputils.go
+++ b/pkg/client/httputils.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/cenkalti/backoff/v4"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -31,6 +30,10 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	accounts "github.com/google/cloud-android-orchestration/pkg/app/accounts"
+
+	"github.com/cenkalti/backoff/v4"
 )
 
 type HTTPHelper struct {
@@ -39,6 +42,7 @@ type HTTPHelper struct {
 	Dumpster          io.Writer
 	AccessToken       string
 	HTTPBasicUsername string
+	HTTPBasicEmail    string
 }
 
 func (h *HTTPHelper) NewGetRequest(path string) *HTTPRequestBuilder {
@@ -195,6 +199,8 @@ func (rb *HTTPRequestBuilder) doWithRetries(retryOpts RetryOptions) (*http.Respo
 		rb.AddHeader("Authorization", "Bearer "+rb.helper.AccessToken)
 	} else if rb.helper.HTTPBasicUsername != "" {
 		rb.SetBasicAuth()
+	} else if rb.helper.HTTPBasicEmail != "" {
+		rb.AddHeader(accounts.UserEmailHeaderKey, rb.helper.HTTPBasicEmail)
 	}
 	if rb.err != nil {
 		return nil, rb.err


### PR DESCRIPTION
Fixes email verification failure in UsernameOnlyAccountManager during OAuth by supporting the Email field.

- For web use case:
    - Add email field in login page
    - Store the entered email in the cookie for further use
  
- For CLI use case:
    - enable setting `UserEmail = <email>` in `cvdr.toml` to configure the email in `UsernameOnlyUser`. For example:
```
Authn = {
  HTTPBasicAuthn = {
    UsernameSrc = "unix",
    UserEmail = <Account used for OAuth>
  }
}
```