### PR TITLE
Get access token for Build API via 3LO OAuth flow

### DIFF
--- a/pkg/cli/authz/oauth.go
+++ b/pkg/cli/authz/oauth.go
@@ -1,0 +1,111 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authz
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"math/rand"
+	"net/http"
+	"net/url"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+func createServer(ch chan string, state string, port string) *http.Server {
+	return &http.Server{
+		Addr:    ":" + port,
+		Handler: http.HandlerFunc(handler(ch, state)),
+	}
+}
+
+func handler(ch chan string, randState string) func(http.ResponseWriter, *http.Request) {
+	return func(rw http.ResponseWriter, req *http.Request) {
+		if req.URL.Path == "/favicon.ico" {
+			http.Error(rw, "error: visiting /favicon.ico", 404)
+			return
+		}
+		if req.FormValue("state") != randState {
+			log.Printf("state: %s doesn't match. (expected: %s)", req.FormValue("state"), randState)
+			http.Error(rw, "invalid state", 500)
+			return
+		}
+		if code := req.FormValue("code"); code != "" {
+			fmt.Fprintf(rw, "<h1>Success</h1>Authorized.")
+			rw.(http.Flusher).Flush()
+			ch <- code
+			return
+		}
+		ch <- ""
+		http.Error(rw, "invalid code", 500)
+	}
+}
+
+func OAuthAccessToken(credential []byte) (*oauth2.Token, error) {
+	oauthConfig, err := google.ConfigFromJSON(credential, "https://www.googleapis.com/auth/androidbuild.internal")
+	if err != nil {
+		return nil, err
+	}
+	redirectURL, err := url.Parse(oauthConfig.RedirectURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse redirect url error: %w", err)
+	}
+	if redirectURL.Hostname() != "localhost" {
+		return nil, errors.New("the redirect url should be `http://localhost:<whatever_port>`")
+	}
+	port := redirectURL.Port()
+	if port == "" {
+		return nil, errors.New("empty port, the redirect url should be `http://localhost:<whatever_port>`")
+	}
+
+	ch := make(chan string)
+	ctx := context.Background()
+
+	// generate a random hex string
+	state := fmt.Sprintf("%.16x%.16x%.16x%.16x", rand.Uint64(), rand.Uint64(), rand.Uint64(), rand.Uint64())
+	ts := createServer(ch, state, port)
+	go func() {
+		err := ts.ListenAndServe()
+		if err != nil {
+			log.Println(err)
+		}
+	}()
+
+	defer ts.Close()
+	authURL := oauthConfig.AuthCodeURL(state)
+	log.Printf("Authorize this app at: %s", authURL)
+	code := <-ch
+
+	tk, err := oauthConfig.Exchange(ctx, code)
+	if err != nil {
+		return nil, err
+	}
+	return tk, nil
+}
+
+func JWTAccessToken(credential []byte) (*oauth2.Token, error) {
+	jwtConfig, err := google.JWTConfigFromJSON(credential, "https://www.googleapis.com/auth/androidbuild.internal")
+	if err != nil {
+		return nil, err
+	}
+	tk, err := jwtConfig.TokenSource(context.Background()).Token()
+	if err != nil {
+		return nil, err
+	}
+	return tk, nil
+}

--- a/pkg/cli/cvd.go
+++ b/pkg/cli/cvd.go
@@ -16,7 +16,6 @@ package cli
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -26,8 +25,8 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/google/cloud-android-orchestration/pkg/cli/authz"
 	"github.com/google/cloud-android-orchestration/pkg/client"
-	"golang.org/x/oauth2/google"
 
 	hoapi "github.com/google/android-cuttlefish/frontend/src/host_orchestrator/api/v1"
 	"github.com/hashicorp/go-multierror"
@@ -358,24 +357,42 @@ func credentialsFactoryFromSource(source string) (CredentialsFactory, error) {
 	case InjectedCredentialsSource:
 		return func() string { return client.InjectedCredentials }, nil
 	default:
-		return jwtAccessToken(source)
+		// expected: `(jwt|oauth):/dir/credentialFile`
+		strs := strings.SplitN(source, ":", 2)
+		if strs == nil || len(strs) != 2 {
+			return nil, fmt.Errorf("unknown credential type, only accept: `none`/`injected`/`%s:'<filepath>'`/`%s:'<filepath>'`", jwtAuthType, oauthAuthType)
+		}
+		authType, filepath := strs[0], strs[1]
+		return accessToken(authType, filepath)
 	}
 }
 
-func jwtAccessToken(filepath string) (func() string, error) {
+const (
+	jwtAuthType   = "jwt"
+	oauthAuthType = "oauth"
+)
+
+func accessToken(authType string, filepath string) (func() string, error) {
 	content, err := os.ReadFile(filepath)
 	if err != nil {
 		return nil, fmt.Errorf("cannot read content from credential filepath %s: %w", filepath, err)
 	}
-	jwtConfig, err := google.JWTConfigFromJSON(content, "https://www.googleapis.com/auth/androidbuild.internal")
-	if err != nil {
-		return nil, err
+	switch authType {
+	case jwtAuthType:
+		tk, err := authz.JWTAccessToken(content)
+		if err != nil {
+			return nil, err
+		}
+		return func() string { return tk.AccessToken }, nil
+	case oauthAuthType:
+		tk, err := authz.OAuthAccessToken(content)
+		if err != nil {
+			return nil, err
+		}
+		return func() string { return tk.AccessToken }, nil
+	default:
+		return nil, fmt.Errorf("unknown authType, get '%s' (expected: '%s' or '%s')", authType, jwtAuthType, oauthAuthType)
 	}
-	tk, err := jwtConfig.TokenSource(context.Background()).Token()
-	if err != nil {
-		return nil, err
-	}
-	return func() string { return tk.AccessToken }, nil
 }
 
 type cvdListResult struct {


### PR DESCRIPTION
- Add a new package `authz` for the authorization
- Move the `jwtAccessToken` in `authz` package
- Implemenet the 3LO auth flow for end users