### PR TITLE
Align WebSocket connection request with normal HTTP request at cvdr

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -30,6 +30,7 @@ import (
 
 	hoapi "github.com/google/android-cuttlefish/frontend/src/host_orchestrator/api/v1"
 	"github.com/google/go-cmp/cmp"
+	"github.com/gorilla/websocket"
 )
 
 func TestRequiredFlags(t *testing.T) {
@@ -131,6 +132,10 @@ func (fakeHostService) GetInfraConfig() (*apiv1.InfraConfig, error) {
 }
 
 func (fakeHostService) ConnectWebRTC(device string, observer wclient.Observer, logger io.Writer, opts client.ConnectWebRTCOpts) (*wclient.Connection, error) {
+	return nil, nil
+}
+
+func (fakeHostService) ConnectADBWebSocket(device string) (*websocket.Conn, error) {
 	return nil, nil
 }
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -191,6 +191,7 @@ func (s *serviceImpl) HostService(host string) HostOrchestratorService {
 		HTTPHelper: s.httpHelper,
 		// Make the cloud orchestrator inject the credentials instead
 		BuildAPICredentialsHeader: DefaultHostOrchestratorCredentialsHeader,
+		ProxyURL:                  s.ProxyURL,
 	}
 	if s.InjectBuildAPICreds {
 		hs.BuildAPICredentialsHeader = headerNameCOInjectBuildAPICreds

--- a/pkg/client/httputils.go
+++ b/pkg/client/httputils.go
@@ -187,9 +187,9 @@ func (rb *HTTPRequestBuilder) JSONResDoWithRetries(ret any, retryOpts RetryOptio
 	return apiError
 }
 
-func (rb *HTTPRequestBuilder) doWithRetries(retryOpts RetryOptions) (*http.Response, error) {
+func (rb *HTTPRequestBuilder) setAuthz() error {
 	if rb.helper.AccessToken != "" && rb.helper.HTTPBasicUsername != "" {
-		return nil, fmt.Errorf("cannot set both access token and basic auth")
+		return fmt.Errorf("cannot set both access token and basic auth")
 	}
 	if rb.helper.AccessToken != "" {
 		rb.AddHeader("Authorization", "Bearer "+rb.helper.AccessToken)
@@ -197,7 +197,14 @@ func (rb *HTTPRequestBuilder) doWithRetries(retryOpts RetryOptions) (*http.Respo
 		rb.SetBasicAuth()
 	}
 	if rb.err != nil {
-		return nil, rb.err
+		return rb.err
+	}
+	return nil
+}
+
+func (rb *HTTPRequestBuilder) doWithRetries(retryOpts RetryOptions) (*http.Response, error) {
+	if err := rb.setAuthz(); err != nil {
+		return nil, err
 	}
 	if err := rb.helper.dumpRequest(rb.request); err != nil {
 		return nil, err


### PR DESCRIPTION
WebSocket connection needs to follow Proxy configuration and Authorization configuration to connect adb websocket backend through Cloud Orchestrator. Change to use same config and header as normal HTTP request does.