### PR TITLE
Use build api credentials source from config

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -111,7 +111,7 @@ const (
 	systemImgBuildTargetFlag  = "system_build_target"
 	numInstancesFlag          = "num_instances"
 	autoConnectFlag           = "auto_connect"
-	credentialsSourceFlag     = "credentials_source"
+	buildAPICredsSourceFlag   = "build_api_creds_source"
 	localBootloaderSrcFlag    = "local_bootloader_src"
 	localCVDHostPkgSrcFlag    = "local_cvd_host_pkg_src"
 	localImagesSrcsFlag       = "local_images_srcs"
@@ -565,7 +565,7 @@ func cvdCommands(opts *subCommandOpts) []*cobra.Command {
 		"Automatically connect through ADB after device is created.")
 	create.Flags().StringVar(
 		&createFlags.BuildAPICredentialsSource,
-		credentialsSourceFlag,
+		buildAPICredsSourceFlag,
 		"none",
 		"Source for the Build API OAuth2 credentials")
 	// Local artifact sources

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -189,6 +189,7 @@ type CreateCVDFlags struct {
 
 func (f *CreateCVDFlags) Update(s *Service) {
 	f.ServiceFlags.Update(s)
+	f.CreateCVDOpts.Update(s)
 	f.CreateHostOpts.Update(s)
 }
 

--- a/pkg/cli/cvd.go
+++ b/pkg/cli/cvd.go
@@ -115,6 +115,12 @@ func (o *CreateCVDOpts) AdditionalInstancesNum() uint32 {
 	return uint32(o.NumInstances - 1)
 }
 
+func (o *CreateCVDOpts) Update(s *Service) {
+	if s.BuildAPICredentialsSource != "" {
+		o.BuildAPICredentialsSource = s.BuildAPICredentialsSource
+	}
+}
+
 func createCVD(service client.Service, createOpts CreateCVDOpts, statePrinter *statePrinter) ([]*RemoteCVD, error) {
 	creator, err := newCVDCreator(service, createOpts, statePrinter)
 	if err != nil {


### PR DESCRIPTION
- The value of this flag determines how the build api access token is retrieved only, let's be specific about it in the name.