### PR TITLE
feat: add Cloud Run deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,11 @@
+SETTING_FILE
 /cvdr
 /cloud_orchestrator
+/scripts/gcp/cloudrun/build-and-deploy.sh
 
 tags
+
+**/.terraform/*
+*.tfstate
+*.tfstate.*
+*.tfvars

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.22-alpine as builder
+RUN apk add --no-cache git
+WORKDIR /go/src/github.com/google/cloud-android-orchestrator
+COPY . .
+RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux go build \
+      -trimpath \
+      -o /app \
+      cmd/cloud_orchestrator/main.go
+
+FROM gcr.io/distroless/base
+COPY --from=builder /app /app
+ADD web/intercept /web/intercept
+CMD ["/app"]

--- a/cmd/cloud_orchestrator/main.go
+++ b/cmd/cloud_orchestrator/main.go
@@ -111,6 +111,8 @@ func LoadOAuth2Config(config *config.Config, sm secrets.SecretManager) *appOAuth
 func LoadAccountManager(config *config.Config) accounts.Manager {
 	var am accounts.Manager
 	switch config.AccountManager.Type {
+	case accounts.IAPType:
+		am = accounts.NewIAPAccountManager()
 	case accounts.GAEAMType:
 		am = accounts.NewGAEUsersAccountManager()
 	case accounts.UnixAMType:

--- a/pkg/app/accounts/iap.go
+++ b/pkg/app/accounts/iap.go
@@ -1,0 +1,68 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package accounts
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"google.golang.org/api/idtoken"
+)
+
+const (
+	IAPType         AMType = "IAP"
+	iapJWTHeaderKey        = "x-goog-iap-jwt-assertion"
+)
+
+type IAPAccountManager struct{}
+
+func NewIAPAccountManager() *IAPAccountManager {
+	return &IAPAccountManager{}
+}
+
+func (g *IAPAccountManager) UserFromRequest(r *http.Request) (User, error) {
+	token := r.Header.Get(iapJWTHeaderKey)
+	if token == "" {
+		return nil, fmt.Errorf("%s header is empty", iapJWTHeaderKey)
+	}
+	audience, ok := os.LookupEnv("IAP_AUDIENCE")
+	if !ok {
+		return nil, errors.New("IAP_AUDIENCE env var not set")
+	}
+	// TODO: if we want to validate the audience then we need to pass it in from the config, otherwise set audience to ""
+	payload, err := idtoken.Validate(context.TODO(), token, audience)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse payload from %s header: %w", iapJWTHeaderKey, err)
+	}
+	email := payload.Claims["email"].(string)
+	if email == "" {
+		return nil, errors.New("empty email claim")
+	}
+	username := strings.SplitN(email, "@", 2)[0]
+	return &IAPUser{username: username, email: email}, nil
+}
+
+type IAPUser struct {
+	username string
+	email    string
+}
+
+func (u *IAPUser) Username() string { return u.username }
+
+func (u *IAPUser) Email() string { return u.email }

--- a/pkg/app/instances/gce.go
+++ b/pkg/app/instances/gce.go
@@ -38,7 +38,7 @@ type GCPIMConfig struct {
 	HostOrchestratorPort int
 	Network              string
 	Subnetwork           string
-	UsePrivateIP         bool
+	UseExternalIP        bool
 	// If true, instances created should be compatible with `acloud CLI`.
 	AcloudCompatible bool
 }
@@ -108,15 +108,15 @@ func (m *GCEInstanceManager) CreateHost(zone string, req *apiv1.CreateHostReques
 	if err := validateRequest(req); err != nil {
 		return nil, err
 	}
-	accessConfig := []*compute.AccessConfig{
-		{
-			Name: "External NAT",
-			Type: "ONE_TO_ONE_NAT",
-		},
-	}
 
-	if m.Config.GCP.UsePrivateIP {
-		accessConfig = []*compute.AccessConfig{}
+	accessConfig := []*compute.AccessConfig{}
+	if m.Config.GCP.UseExternalIP {
+		accessConfig = []*compute.AccessConfig{
+			{
+				Name: "External NAT",
+				Type: "ONE_TO_ONE_NAT",
+			},
+		}
 	}
 
 	payload := &compute.Instance{

--- a/scripts/gcp/cloudrun/.terraform.lock.hcl
+++ b/scripts/gcp/cloudrun/.terraform.lock.hcl
@@ -1,0 +1,81 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "5.34.0"
+  constraints = ">= 4.50.0, < 6.0.0"
+  hashes = [
+    "h1:fi9xftzKft61lt4vI0oXgzEwpLtMW4D3S3/T63SsO7w=",
+    "zh:143c88bb74631041c291ebf7b6213467bf376d3775a33815785939dc102fac09",
+    "zh:1616ac79345f472b33fcc388eaf4a8a3002e4cc3a5e8748d60d6f4786d0d16dc",
+    "zh:554ce78e73349ac2c893a74b6981f5e55169ca16f4d0f239e6ccdecadbe1c9e1",
+    "zh:8022f97aa907685b2eb6c39d5411cf2be2448c6f3b7fbeaf9c06618d376ac4bc",
+    "zh:85f1fe3628954c35379cc05b895091ec8fe8ba0a5610bc9660492d5be65d4902",
+    "zh:873fb64fca79695aa930cd868b41ac498809eb76bc3292e41460d916c6fa3538",
+    "zh:8d3c5112a4abf14b42d769f78373e66f2c2f5f03a7e6544d80019a695bd9b198",
+    "zh:93cbcfa38991965b976d1973bc528d666006b5247c3fda00c714d0f3a2b62d3e",
+    "zh:b7710246637aee522a4ea4c1b4f0effb83b701546124ae90c8b4afb97ce03aba",
+    "zh:e4e02fe946ccbe192b6bbc6bed5715cf68084f1faadc134ed99d5e732429d2ca",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fb6b1e4fb2d019d2740aa21b5ecd5f0609f562633a78604a96c14c94aff762b4",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version     = "5.34.0"
+  constraints = ">= 4.50.0, < 6.0.0"
+  hashes = [
+    "h1:08e6reS//101sFAQCEPWg+eImpE4JeBktf4nNt8pEzg=",
+    "zh:01619cfe684471dc88d470cf157f7adc659a2f6849346d6be2a71efe1cbd0250",
+    "zh:1b6b2401862aaaf08819cf83b27a147957f0bcc1821a3b94a438788760cb65ad",
+    "zh:30d3fbaa204dd1d197d01ed5385a5d325fd8d313a5fdcf7cdd80209f1740247f",
+    "zh:461d084c0a0590785134218d57df39f34863a8977e4e925585eea085c86c97b5",
+    "zh:534bc4652861bdcbe0451673269d326477781d70a9f03cae3b780d574f29f841",
+    "zh:6e8abcd37a9609b05aab3529ccc3414b6d1258b124e58754b62f28fd4f3877a7",
+    "zh:838a31873ce35e40e52ba0513aec5ff519159e99459829f0ea590eb62714801a",
+    "zh:9387550c9e45e68c7ac5d6839a8f88e8e525ebf81a4c76847f7c05f13bf5dc19",
+    "zh:997ac33e5d72f0aecfddd5235ba4dbe82b5bbaf811b801849e419942e204a12b",
+    "zh:a66fbccde0dd854f764bf247576eaea4898966b6814db232fa45e789dc2ca014",
+    "zh:d60efed82a54ff41a8f2380f83fefd9477616f49296e349b5a41fccb558fde08",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.5.1"
+  hashes = [
+    "h1:8oTPe2VUL6E2d3OcrvqyjI4Nn/Y/UEQN26WLk5O/B0g=",
+    "zh:0af29ce2b7b5712319bf6424cb58d13b852bf9a777011a545fac99c7fdcdf561",
+    "zh:126063ea0d79dad1f68fa4e4d556793c0108ce278034f101d1dbbb2463924561",
+    "zh:196bfb49086f22fd4db46033e01655b0e5e036a5582d250412cc690fa7995de5",
+    "zh:37c92ec084d059d37d6cffdb683ccf68e3a5f8d2eb69dd73c8e43ad003ef8d24",
+    "zh:4269f01a98513651ad66763c16b268f4c2da76cc892ccfd54b401fff6cc11667",
+    "zh:51904350b9c728f963eef0c28f1d43e73d010333133eb7f30999a8fb6a0cc3d8",
+    "zh:73a66611359b83d0c3fcba2984610273f7954002febb8a57242bbb86d967b635",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7ae387993a92bcc379063229b3cce8af7eaf082dd9306598fcd42352994d2de0",
+    "zh:9e0f365f807b088646db6e4a8d4b188129d9ebdbcf2568c8ab33bddd1b82c867",
+    "zh:b5263acbd8ae51c9cbffa79743fbcadcb7908057c87eb22fd9048268056efbc4",
+    "zh:dfcd88ac5f13c0d04e24be00b686d069b4879cc4add1b7b1a8ae545783d97520",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.6.2"
+  constraints = ">= 2.1.0"
+  hashes = [
+    "h1:wmG0QFjQ2OfyPy6BB7mQ57WtoZZGGV07uAPQeDmIrAE=",
+    "zh:0ef01a4f81147b32c1bea3429974d4d104bbc4be2ba3cfa667031a8183ef88ec",
+    "zh:1bcd2d8161e89e39886119965ef0f37fcce2da9c1aca34263dd3002ba05fcb53",
+    "zh:37c75d15e9514556a5f4ed02e1548aaa95c0ecd6ff9af1119ac905144c70c114",
+    "zh:4210550a767226976bc7e57d988b9ce48f4411fa8a60cd74a6b246baf7589dad",
+    "zh:562007382520cd4baa7320f35e1370ffe84e46ed4e2071fdc7e4b1a9b1f8ae9b",
+    "zh:5efb9da90f665e43f22c2e13e0ce48e86cae2d960aaf1abf721b497f32025916",
+    "zh:6f71257a6b1218d02a573fc9bff0657410404fb2ef23bc66ae8cd968f98d5ff6",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:9647e18f221380a85f2f0ab387c68fdafd58af6193a932417299cdcae4710150",
+    "zh:bb6297ce412c3c2fa9fec726114e5e0508dd2638cad6a0cb433194930c97a544",
+    "zh:f83e925ed73ff8a5ef6e3608ad9225baa5376446349572c2449c0c0b3cf184b7",
+    "zh:fbef0781cb64de76b1df1ca11078aecba7800d82fd4a956302734999cfd9a4af",
+  ]
+}

--- a/scripts/gcp/cloudrun/README.md
+++ b/scripts/gcp/cloudrun/README.md
@@ -1,0 +1,21 @@
+# Steps
+
+## STEP 1: Prepare `terraform.tfvars`
+
+Look at the `variables.tf` and provide necessary variables and/or override defaults via `terraform.tfvars`.
+
+## STEP 2: Set up project
+
+```
+$ cd terraform
+$ terraform plan
+$ terraform apply
+```
+
+`terraform apply` creates a `build-and-deploy.sh` which you need to run after `terraform apply` ends successfully.
+
+## STEP 3: Deploy Cloud Run service
+
+```
+$ ./build-and-deploy.sh
+```

--- a/scripts/gcp/cloudrun/build-and-deploy.sh.tmpl
+++ b/scripts/gcp/cloudrun/build-and-deploy.sh.tmpl
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+pushd ../../../ > /dev/null
+
+gcloud auth configure-docker --quiet \
+    ${REGION}-docker.pkg.dev
+
+docker build -t ${IMAGE} .
+
+docker push ${IMAGE}
+
+gcloud run deploy ${CLOUD_RUN_NAME} \
+  --image=${IMAGE} \
+  --no-allow-unauthenticated \
+  --port=8080 \
+  --service-account=${SA_EMAIL} \
+  --set-env-vars='CONFIG_FILE=/config/conf.toml' --set-env-vars='IAP_AUDIENCE=/projects/${PROJECT_NUMBER}/global/backendServices/${BACKEND_SERVICE_ID}' \
+  --set-secrets=/config/conf.toml=cloud-orchestrator-config:latest \
+  --ingress=internal-and-cloud-load-balancing \
+  --vpc-connector=${CONNECTOR_ID} \
+  --vpc-egress=private-ranges-only \
+  --region=${REGION} \
+  --project=${PROJECT_ID}
+
+gcloud run services add-iam-policy-binding ${CLOUD_RUN_NAME} \
+    --region=${REGION} \
+    --member=serviceAccount:service-${PROJECT_NUMBER}@gcp-sa-iap.iam.gserviceaccount.com \
+    --role=roles/run.invoker \
+    --project=${PROJECT_ID}
+
+cat << EOF > SETTING_FILE
+  access_settings:
+    oauth_settings:
+      programmatic_clients: ["${OAUTH_CLIENT_ID}"]
+EOF
+
+gcloud iap settings set SETTING_FILE \
+  --project=${PROJECT_ID} \
+  --resource-type=iap_web \
+  --service=${BACKEND_SERVICE_NAME}
+
+popd > /dev/null

--- a/scripts/gcp/cloudrun/conf.toml.tmpl
+++ b/scripts/gcp/cloudrun/conf.toml.tmpl
@@ -47,7 +47,7 @@ HostImageFamily = "projects/${PROJECT_ID}/global/images/family/cf-debian11-amd64
 HostOrchestratorPort = 2443
 Network = "${NETWORK}"
 Subnetwork = "${SUBNETWORK}"
-UsePrivateIP = ${USE_PRIVATE_IPS}
+UseExternalIP = ${USE_EXTERNAL_IP}
 
 [WebRTC]
 STUNServers = ["stun:stun.l.google.com:19302"]

--- a/scripts/gcp/cloudrun/conf.toml.tmpl
+++ b/scripts/gcp/cloudrun/conf.toml.tmpl
@@ -1,0 +1,53 @@
+# Copyright 2024 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Template to generate the service `conf.toml` file
+#
+# export PROJECT_ID="foo"
+# envsubst < conf.toml.tmpl > conf.toml
+
+WebStaticFilesPath = "web"
+
+[AccountManager]
+Type = "IAP"
+
+# TODO: This could be emtpy for gae vanilla aosp.
+[AccountManager.OAuth2]
+Provider = "Google"
+RedirectURL = "http://foo.bar/oauth2callback"
+
+[SecretManager]
+Type = ""
+
+[EncryptionService]
+Type = "Fake"
+
+[DatabaseService]
+Type = "InMemory"
+
+[InstanceManager]
+Type = "GCP"
+HostOrchestratorProtocol = "https"
+AllowSelfSignedHostSSLCertificate = true
+
+[InstanceManager.GCP]
+ProjectID = "${PROJECT_ID}"
+HostImageFamily = "projects/${PROJECT_ID}/global/images/family/cf-debian11-amd64"
+HostOrchestratorPort = 2443
+Network = "${NETWORK}"
+Subnetwork = "${SUBNETWORK}"
+UsePrivateIP = ${USE_PRIVATE_IPS}
+
+[WebRTC]
+STUNServers = ["stun:stun.l.google.com:19302"]

--- a/scripts/gcp/cloudrun/main.tf
+++ b/scripts/gcp/cloudrun/main.tf
@@ -80,7 +80,7 @@ resource "google_secret_manager_secret_version" "secret-version-basic" {
     PROJECT_ID      = var.project_id,
     NETWORK         = google_compute_network.network.id,
     SUBNETWORK      = google_compute_subnetwork.subnetwork.id
-    USE_PRIVATE_IPS = var.use_private_ips
+    USE_EXTERNAL_IP = var.use_external_ip
   })
 }
 
@@ -215,7 +215,7 @@ resource "google_vpc_access_connector" "connector" {
 }
 
 module "cloud-nat" {
-  for_each      = var.use_private_ips ? toset(["1"]) : toset([])
+  count         = var.use_external_ip ? 0 : 1
   source        = "terraform-google-modules/cloud-nat/google"
   version       = "~> 5.0"
   project_id    = var.project_id

--- a/scripts/gcp/cloudrun/main.tf
+++ b/scripts/gcp/cloudrun/main.tf
@@ -1,0 +1,260 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  apis = toset([
+    "artifactregistry.googleapis.com",
+    "compute.googleapis.com",
+    "iap.googleapis.com",
+    "run.googleapis.com",
+    "secretmanager.googleapis.com",
+    "vpcaccess.googleapis.com",
+  ])
+}
+
+provider "google" {
+  project = var.project_id
+}
+
+provider "google-beta" {
+  project = var.project_id
+}
+
+resource "google_project_service" "apis" {
+  for_each = local.apis
+  service  = each.key
+}
+
+resource "google_project_service_identity" "iap" {
+  provider = google-beta
+
+  project = data.google_project.project.project_id
+  service = "iap.googleapis.com"
+}
+
+data "google_project" "project" {
+}
+
+resource "google_compute_project_metadata_item" "disable-oslogin" {
+  key   = "enable-oslogin"
+  value = "FALSE"
+}
+
+resource "google_artifact_registry_repository" "my-repo" {
+  location      = var.region
+  repository_id = var.artifact_repository_id
+  format        = "DOCKER"
+  depends_on = [
+    google_project_service.apis
+  ]
+}
+
+// Secret Manager
+resource "google_secret_manager_secret" "co-config" {
+  secret_id = "cloud-orchestrator-config"
+
+  replication {
+    auto {}
+  }
+  depends_on = [
+    google_project_service.apis
+  ]
+}
+
+resource "google_secret_manager_secret_version" "secret-version-basic" {
+  secret = google_secret_manager_secret.co-config.id
+  secret_data = templatefile("conf.toml.tmpl", {
+    PROJECT_ID      = var.project_id,
+    NETWORK         = google_compute_network.network.id,
+    SUBNETWORK      = google_compute_subnetwork.subnetwork.id
+    USE_PRIVATE_IPS = var.use_private_ips
+  })
+}
+
+resource "google_iap_brand" "project_brand" {
+  support_email     = var.oauth_support_email
+  application_title = "Cloud Orchestrator"
+  project           = var.project_id
+  depends_on = [
+    google_project_service.apis
+  ]
+}
+
+resource "google_iap_client" "project_client" {
+  display_name = "IAP-co-backend-service"
+  brand        = google_iap_brand.project_brand.name
+}
+
+resource "google_iap_web_backend_service_iam_member" "sa_member" {
+  project             = var.project_id
+  web_backend_service = module.lb-http.backend_services.default.name
+  role                = "roles/iap.httpsResourceAccessor"
+  member              = google_service_account.service_account.member
+}
+
+resource "google_iap_web_backend_service_iam_member" "member" {
+  for_each            = var.service_accessors
+  project             = var.project_id
+  web_backend_service = module.lb-http.backend_services.default.name
+  role                = "roles/iap.httpsResourceAccessor"
+  member              = each.key
+}
+
+module "lb-http" {
+  source  = "terraform-google-modules/lb-http/google//modules/serverless_negs"
+  version = "~> 11.0"
+
+  name    = var.lb_name
+  project = var.project_id
+
+  load_balancing_scheme           = "EXTERNAL_MANAGED"
+  ssl                             = true
+  managed_ssl_certificate_domains = [var.domain]
+  http_forward                    = false
+
+  backends = {
+    default = {
+      protocol    = "HTTPS"
+      description = null
+      groups = [
+        {
+          group = google_compute_region_network_endpoint_group.serverless_neg.id
+        }
+      ]
+      enable_cdn = false
+
+      iap_config = {
+        enable               = true
+        oauth2_client_id     = google_iap_client.project_client.client_id
+        oauth2_client_secret = google_iap_client.project_client.secret
+      }
+      log_config = {
+        enable = false
+      }
+    }
+  }
+  depends_on = [
+    google_project_service.apis
+  ]
+}
+
+resource "google_compute_region_network_endpoint_group" "serverless_neg" {
+  provider              = google-beta
+  name                  = "serverless-neg"
+  network_endpoint_type = "SERVERLESS"
+  region                = var.region
+  cloud_run {
+    service = var.cloud_run_name
+  }
+  depends_on = [
+    google_project_service.apis
+  ]
+}
+
+resource "google_service_account" "service_account" {
+  account_id   = "cloud-orchestrator"
+  display_name = "Service Account used for Cloud Orchestrator"
+  depends_on = [
+    google_project_service.apis
+  ]
+}
+
+resource "google_service_account_iam_member" "token_creators" {
+  for_each           = var.service_accessors
+  service_account_id = google_service_account.service_account.id
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = each.key
+}
+
+resource "google_secret_manager_secret_iam_member" "member" {
+  secret_id = google_secret_manager_secret.co-config.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = google_service_account.service_account.member
+}
+
+resource "google_project_iam_member" "member" {
+  project = var.project_id
+  role    = "roles/compute.admin"
+  member  = google_service_account.service_account.member
+}
+
+# Networking
+resource "google_compute_network" "network" {
+  name                    = "co-network"
+  auto_create_subnetworks = false
+  depends_on = [
+    google_project_service.apis
+  ]
+}
+
+resource "google_compute_subnetwork" "subnetwork" {
+  name          = "test-subnetwork"
+  ip_cidr_range = "10.2.0.0/16"
+  region        = var.region
+  network       = google_compute_network.network.id
+}
+
+resource "google_vpc_access_connector" "connector" {
+  region        = var.region
+  name          = var.serverless_connector_name
+  ip_cidr_range = "10.8.0.0/28"
+  network       = google_compute_network.network.id
+}
+
+module "cloud-nat" {
+  for_each      = var.use_private_ips ? toset(["1"]) : toset([])
+  source        = "terraform-google-modules/cloud-nat/google"
+  version       = "~> 5.0"
+  project_id    = var.project_id
+  region        = var.region
+  router        = "cloud-nat-${var.region}"
+  create_router = true
+  network       = google_compute_network.network.id
+}
+
+# Firewall
+resource "google_compute_firewall" "default" {
+  name    = "allow-cloud-orchestrator"
+  network = google_compute_network.network.name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["1080", "1443", "15550-15599"]
+  }
+
+  allow {
+    protocol = "udp"
+    ports    = ["15550-15599"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+}
+
+resource "local_file" "build_and_deploy" {
+  content = templatefile("build-and-deploy.sh.tmpl", {
+    IMAGE                = "${google_artifact_registry_repository.my-repo.location}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.my-repo.name}/cloud-orchestrator:latest",
+    PROJECT_ID           = var.project_id,
+    PROJECT_NUMBER       = data.google_project.project.number,
+    REGION               = var.region,
+    CLOUD_RUN_NAME       = var.cloud_run_name,
+    SA_EMAIL             = google_service_account.service_account.email,
+    CONNECTOR_ID         = google_vpc_access_connector.connector.id,
+    BACKEND_SERVICE_NAME = nonsensitive(module.lb-http.backend_services.default.name),
+    BACKEND_SERVICE_ID   = nonsensitive(module.lb-http.backend_services.default.generated_id),
+    OAUTH_CLIENT_ID      = google_iap_client.project_client.client_id,
+  })
+  filename = "${path.root}/build-and-deploy.sh"
+}

--- a/scripts/gcp/cloudrun/variables.tf
+++ b/scripts/gcp/cloudrun/variables.tf
@@ -64,8 +64,8 @@ variable "serverless_connector_name" {
   default     = "co-vpc-connector"
 }
 
-variable "use_private_ips" {
-  description = "Toggle to use private IPs in GCP"
+variable "use_external_ip" {
+  description = "Toggle to use external IPs in GCP"
   type        = bool
-  default     = true
+  default     = false
 }

--- a/scripts/gcp/cloudrun/variables.tf
+++ b/scripts/gcp/cloudrun/variables.tf
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  type = string
+}
+
+variable "region" {
+  description = "Location for load balancer and Cloud Run resources"
+  type        = string
+  default     = "europe-west3"
+}
+
+variable "domain" {
+  description = "Domain name to run the load balancer on."
+  type        = string
+}
+
+variable "lb_name" {
+  description = "Name for load balancer and associated resources"
+  type        = string
+  default     = "tf-cr-lb"
+}
+
+variable "oauth_support_email" {
+  description = "eMail address displayed to users regarding questions about their consent"
+  type        = string
+}
+
+variable "artifact_repository_id" {
+  description = "The name of the Artificat Repository"
+  type        = string
+  default     = "cloud-android-orchestration"
+}
+
+variable "service_accessors" {
+  description = "List of principals which should be able to call the cloud orchestrator"
+  type        = set(string)
+  default     = []
+}
+
+variable "cloud_run_name" {
+  description = "The name of the Cloud Run service"
+  type        = string
+  default     = "cloud-orchestrator"
+}
+
+variable "serverless_connector_name" {
+  description = "The name of the Serverless VPC Connector"
+  type        = string
+  default     = "co-vpc-connector"
+}
+
+variable "use_private_ips" {
+  description = "Toggle to use private IPs in GCP"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
This PR adds the Terraform setup and the necessary changes to Cloud Orchestrator to be deployed on Cloud Run protected by IAP. Additionally it includes the possibility to use GCE instances with private IPs only.


Co-authored-by: David Gleich <gleichda@google.com>