### PR TITLE
Allow to specify boot disk size for GCE instances and auto delete boot disk

### DIFF
--- a/api/v1/instancemanager.go
+++ b/api/v1/instancemanager.go
@@ -12,8 +12,6 @@ type Zone struct {
 type HostInstance struct {
 	// [Output Only] Instance name.
 	Name string `json:"name,omitempty"`
-	// [Output Only] Boot disk size in GB.
-	BootDiskSizeGB int64 `json:"boot_disk_size_gb,omitempty"`
 	// GCP specific properties.
 	GCP *GCPInstance `json:"gcp,omitempty"`
 	// Docker specific properties.
@@ -35,6 +33,8 @@ type GCPInstance struct {
 	MinCPUPlatform string `json:"min_cpu_platform"`
 	// List of accelerator configurations.
 	AcceleratorConfigs []*AcceleratorConfig `json:"accelerator_configs,omitempty"`
+	// Boot disk size in GB; Defaults to SourceImage disk size if unset
+	BootDiskSizeGB int64 `json:"boot_disk_size_gb,omitempty"`
 }
 
 type AcceleratorConfig struct {

--- a/pkg/app/instances/gce.go
+++ b/pkg/app/instances/gce.go
@@ -141,6 +141,9 @@ func (m *GCEInstanceManager) CreateHost(zone string, req *apiv1.CreateHostReques
 			labelCreatedBy: user.Username(),
 		},
 	}
+	if req.HostInstance.GCP.BootDiskSizeGB != 0 {
+		payload.Disks[0].InitializeParams.DiskSizeGb = req.HostInstance.GCP.BootDiskSizeGB
+	}
 	if len(req.HostInstance.GCP.AcceleratorConfigs) != 0 {
 		configs := []*compute.AcceleratorConfig{}
 		for _, c := range req.HostInstance.GCP.AcceleratorConfigs {
@@ -269,7 +272,6 @@ func (m *GCEInstanceManager) getHostInstance(zone string, host string) (*compute
 func validateRequest(r *apiv1.CreateHostRequest) error {
 	if r.HostInstance == nil ||
 		r.HostInstance.Name != "" ||
-		r.HostInstance.BootDiskSizeGB != 0 ||
 		r.HostInstance.GCP == nil ||
 		r.HostInstance.GCP.MachineType == "" {
 		return errors.NewBadRequestError("invalid CreateHostRequest", nil)
@@ -287,11 +289,11 @@ func BuildHostInstance(in *compute.Instance) (*apiv1.HostInstance, error) {
 		log.Printf("invalid host instance %q: has %d (more than one) disks", in.SelfLink, disksLen)
 	}
 	return &apiv1.HostInstance{
-		Name:           in.Name,
-		BootDiskSizeGB: in.Disks[0].DiskSizeGb,
+		Name: in.Name,
 		GCP: &apiv1.GCPInstance{
 			MachineType:    path.Base(in.MachineType),
 			MinCPUPlatform: in.MinCpuPlatform,
+			BootDiskSizeGB: in.Disks[0].DiskSizeGb,
 		},
 	}, nil
 }

--- a/pkg/app/instances/gce_test.go
+++ b/pkg/app/instances/gce_test.go
@@ -82,7 +82,6 @@ func TestCreateHostInvalidRequests(t *testing.T) {
 	}{
 		{func(r *apiv1.CreateHostRequest) { r.HostInstance = nil }},
 		{func(r *apiv1.CreateHostRequest) { r.HostInstance.Name = "foo" }},
-		{func(r *apiv1.CreateHostRequest) { r.HostInstance.BootDiskSizeGB = 1 }},
 		{func(r *apiv1.CreateHostRequest) { r.HostInstance.GCP = nil }},
 		{func(r *apiv1.CreateHostRequest) { r.HostInstance.GCP.MachineType = "" }},
 	}
@@ -142,6 +141,7 @@ func TestCreateHostRequestBody(t *testing.T) {
 				GCP: &apiv1.GCPInstance{
 					MachineType:    "n1-standard-1",
 					MinCPUPlatform: "Intel Haswell",
+					BootDiskSizeGB: 100,
 				},
 			},
 		},
@@ -156,6 +156,7 @@ func TestCreateHostRequestBody(t *testing.T) {
       "autoDelete": true,
       "boot": true,
       "initializeParams": {
+        "diskSizeGb": "100",
         "sourceImage": "projects/test-project-releases/global/images/family/foo"
       }
     }
@@ -638,11 +639,11 @@ func TestBuildHostInstance(t *testing.T) {
 	got, err := BuildHostInstance(input)
 
 	want := apiv1.HostInstance{
-		Name:           "foo",
-		BootDiskSizeGB: 10,
+		Name: "foo",
 		GCP: &apiv1.GCPInstance{
 			MachineType:    "n1-standard-1",
 			MinCPUPlatform: "Intel Haswell",
+			BootDiskSizeGB: 10,
 		},
 	}
 	if diff := cmp.Diff(&want, got); diff != "" {

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -86,12 +86,14 @@ const (
 
 	gcpMachineTypeFlag    = "gcp_machine_type"
 	gcpMinCPUPlatformFlag = "gcp_min_cpu_platform"
+	gcpBootDiskSizeGB     = "gcp_boot_disk_size_gb"
 )
 
 const (
 	acceleratorFlagDesc       = "Configuration to attach accelerator cards, i.e: --accelerator type=nvidia-tesla-p100,count=1"
 	gcpMachineTypeFlagDesc    = "Indicates the machine type"
 	gcpMinCPUPlatformFlagDesc = "Specifies a minimum CPU platform for the VM instance"
+	gcpBootDiskSizeGBDesc     = "Specifies the Boot Disk size for the VM instance"
 )
 
 const (
@@ -481,6 +483,8 @@ func hostCommand(opts *subCommandOpts) *cobra.Command {
 		opts.InitialConfig.DefaultService().Host.GCP.MachineType, gcpMachineTypeFlagDesc)
 	create.Flags().StringVar(&createFlags.GCP.MinCPUPlatform, gcpMinCPUPlatformFlag,
 		opts.InitialConfig.DefaultService().Host.GCP.MinCPUPlatform, gcpMinCPUPlatformFlagDesc)
+	create.Flags().Int64Var(&createFlags.GCP.BootDiskSizeGB, gcpBootDiskSizeGB,
+		opts.InitialConfig.DefaultService().Host.GCP.BootDiskSizeGB, gcpBootDiskSizeGBDesc)
 	list := &cobra.Command{
 		Use:     "list",
 		Short:   "Lists hosts.",

--- a/pkg/cli/config.go
+++ b/pkg/cli/config.go
@@ -29,6 +29,7 @@ import (
 type GCPHostConfig struct {
 	MachineType    string `json:"machine_type,omitempty"`
 	MinCPUPlatform string `json:"min_cpu_platform,omitempty"`
+	BootDiskSizeGB int64  `json:"boot_disk_size_gb,omitempty"`
 }
 
 type HostConfig struct {

--- a/pkg/cli/config_test.go
+++ b/pkg/cli/config_test.go
@@ -61,7 +61,8 @@ BuildAPICredentialsSource = "injected"
 Host = {
   GCP = {
     MachineType = "machine_type",
-    MinCPUPlatform = "cpu_platform"
+    MinCPUPlatform = "cpu_platform",
+    BootDiskSizeGB = 10
   }
 }
 Authn = {

--- a/pkg/cli/host.go
+++ b/pkg/cli/host.go
@@ -28,11 +28,13 @@ type CreateHostOpts struct {
 func (f *CreateHostOpts) Update(s *Service) {
 	f.GCP.MachineType = s.Host.GCP.MachineType
 	f.GCP.MinCPUPlatform = s.Host.GCP.MinCPUPlatform
+	f.GCP.BootDiskSizeGB = s.Host.GCP.BootDiskSizeGB
 }
 
 type CreateGCPHostOpts struct {
 	MachineType        string
 	MinCPUPlatform     string
+	BootDiskSizeGB     int64
 	AcceleratorConfigs []acceleratorConfig
 }
 
@@ -42,6 +44,7 @@ func createHost(srvClient client.Client, opts CreateHostOpts) (*apiv1.HostInstan
 			GCP: &apiv1.GCPInstance{
 				MachineType:    opts.GCP.MachineType,
 				MinCPUPlatform: opts.GCP.MinCPUPlatform,
+				BootDiskSizeGB: opts.GCP.BootDiskSizeGB,
 			},
 		},
 	}


### PR DESCRIPTION
- Add option for GCE To specify boot disk size; It will fall back to the image size if unset (Keeping the same default)
- Move the `BootDiskSizeGB` to be GCP Only as it is used nowhere else and is GCP specific
- Configure Boot disks to auto delete to properly clean up

New config would look like:
```
SystemDefaultService = "dockerIM"
[Services.dockerIM]
ServiceURL = "https://myservice.example.com"
Zone = "europe-west3-a"

Host={
	GCP={
		MachineType = "n1-standard-4",
		MinCPUPlatform = "Intel Haswell",
		BootDiskSizeGB = 100
	}
}
Authn={
	OIDCToken={
		TokenFile = "/tmp/cvdr_oidc.token"
	}
}
```