### PR TITLE
Avoid double close of wsWrapper

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -1429,7 +1429,6 @@ func runConnectionWebSocketAgentCommand(flags *ConnectFlags, c *command, args []
 		pos:    0,
 		buf:    nil,
 	}
-	defer wsWrapper.Close()
 	go func() {
 		io.Copy(wsWrapper, tcpConn)
 		wsWrapper.Close()


### PR DESCRIPTION
Kept the close in the same goroutine where it's written to to prevent potential SIGPIPE errors.