### PR TITLE
Fix many golint errors

### DIFF
--- a/pkg/app/accounts/accounts.go
+++ b/pkg/app/accounts/accounts.go
@@ -35,5 +35,5 @@ type AMType string
 
 type Config struct {
 	Type   AMType
-	OAuth2 appOAuth2.OAuth2Config
+	OAuth2 appOAuth2.Config
 }

--- a/pkg/app/app_test.go
+++ b/pkg/app/app_test.go
@@ -453,13 +453,13 @@ func TestBadCSRFTokensInRescindAuth(t *testing.T) {
 		Values url.Values
 	}{{"MissingToken", url.Values{}}, {"WrongToken", url.Values{"csrf_token": []string{"wrongtoken"}}}}
 
-	const sessionId = "somesessionid"
+	const sessionID = "somesessionid"
 
 	for _, td := range testData {
 		t.Run(td.Name, func(t *testing.T) {
 			dbs := database.NewInMemoryDBService()
 			dbs.CreateOrUpdateSession(session.Session{
-				Key:         sessionId,
+				Key:         sessionID,
 				OAuth2State: "righttoken",
 			})
 			controller := NewApp(&testInstanceManager{}, &testAccountManager{}, nil, nil, dbs, "", nil, config.WebRTCConfig{}, &config.Config{})
@@ -472,8 +472,8 @@ func TestBadCSRFTokensInRescindAuth(t *testing.T) {
 			}
 			req.Header["Content-Type"] = []string{"application/x-www-form-urlencoded"}
 			req.AddCookie(&http.Cookie{
-				Name:  sessionIdCookie,
-				Value: sessionId,
+				Name:  sessionIDCookie,
+				Value: sessionID,
 			})
 			res, err := http.DefaultClient.Do(req)
 			if err != nil {

--- a/pkg/app/encryption/fake.go
+++ b/pkg/app/encryption/fake.go
@@ -29,7 +29,7 @@ func (es *FakeEncryptionService) Encrypt(plaintext []byte) ([]byte, error) {
 	// encrypted message is different than the original.
 	const mask byte = 255
 	res := make([]byte, len(plaintext))
-	for i := 0; i < len(plaintext); i += 1 {
+	for i := 0; i < len(plaintext); i++ {
 		res[i] = plaintext[i] ^ mask
 	}
 	return res, nil

--- a/pkg/app/instances/gce_test.go
+++ b/pkg/app/instances/gce_test.go
@@ -188,9 +188,9 @@ func TestCreateHostExternalIpRequestBody(t *testing.T) {
 	}))
 	defer ts.Close()
 	testService := buildTestService(t, ts)
-	testConfigExternalIp := testConfig
-	testConfigExternalIp.GCP.UseExternalIP = true
-	im := NewGCEInstanceManager(testConfigExternalIp, testService, testNameGenerator)
+	testConfigExternalIP := testConfig
+	testConfigExternalIP.GCP.UseExternalIP = true
+	im := NewGCEInstanceManager(testConfigExternalIP, testService, testNameGenerator)
 
 	im.CreateHost("us-central1-a",
 		&apiv1.CreateHostRequest{

--- a/pkg/app/oauth2/oauth2.go
+++ b/pkg/app/oauth2/oauth2.go
@@ -26,7 +26,7 @@ import (
 	"golang.org/x/oauth2/google"
 )
 
-type OAuth2Config struct {
+type Config struct {
 	Provider    string
 	RedirectURL string
 }

--- a/pkg/cli/conn.go
+++ b/pkg/cli/conn.go
@@ -133,7 +133,7 @@ type findOrConnRet struct {
 	Error      error
 }
 
-func FindOrConnect(controlDir string, cvd RemoteCVDLocator, srvClient client.Client, localICEConfig *wclient.ICEConfig) (findOrConnRet, error) {
+func findOrConnect(controlDir string, cvd RemoteCVDLocator, srvClient client.Client, localICEConfig *wclient.ICEConfig) (findOrConnRet, error) {
 	statuses, err := listCVDConnectionsByHost(controlDir, cvd.Host)
 	// Even with an error some connections may have been listed.
 	if s, ok := statuses[cvd]; ok {

--- a/pkg/cli/cvd.go
+++ b/pkg/cli/cvd.go
@@ -659,7 +659,7 @@ func GetHostOutRelativePath(targetArch string) (string, error) {
 	}
 	relativePath, ok := m[targetArch]
 	if !ok {
-		return "", fmt.Errorf("Unexpected target architecture: %q", targetArch)
+		return "", fmt.Errorf("unexpected target architecture: %q", targetArch)
 	}
 	return relativePath, nil
 }

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -45,7 +45,7 @@ func TestDeleteHosts(t *testing.T) {
 		}
 	}))
 	defer ts.Close()
-	opts := &ClientOptions{
+	opts := &Options{
 		RootEndpoint: ts.URL,
 		DumpOut:      io.Discard,
 	}


### PR DESCRIPTION
Removed all errors shown in: \
`$ golint -min_confidence 0 ./... | grep -v comment | grep -v api/v1`

Reasoning:
- Fixing lint errors for writing comment takes too much effort.
- Fixing lint errors in `api/v1/*` may break API surface.