### PR TITLE
Updated GAE Go runtime to 1.22

### DIFF
--- a/scripts/gcp/app/app.yaml.tmpl
+++ b/scripts/gcp/app/app.yaml.tmpl
@@ -20,7 +20,7 @@
 # envsubst < app.yaml.tmpl > app.yaml
 
 service: ${SERVICE}
-runtime: go119
+runtime: go122
 main: ./cmd/cloud_orchestrator
 vpc_access_connector:
     name: "projects/${PROJECT_ID}/locations/${SERVERLESS_VPC_REGION}/connectors/co-vpc-connector"


### PR DESCRIPTION
Go Runtime 1.19 is deprecated, updating to the latest supported version