### PR TITLE
Fixed acceleratorType value

### DIFF
--- a/api/v1/instancemanager.go
+++ b/api/v1/instancemanager.go
@@ -40,8 +40,7 @@ type GCPInstance struct {
 type AcceleratorConfig struct {
 	// Number of accelerators.
 	AcceleratorCount int64 `json:"accelerator_count,omitempty"`
-	// Full or partial URL of the accelerator type resource.
-	// For example: `projects/my-project/zones/us-central1-c/acceleratorTypes/nvidia-tesla-p100`
+	// Name of the accelerator type (e.g. nvidia-tesla-p100).
 	AcceleratorType string `json:"accelerator_type,omitempty"`
 }
 

--- a/pkg/app/instances/gce.go
+++ b/pkg/app/instances/gce.go
@@ -156,7 +156,7 @@ func (m *GCEInstanceManager) CreateHost(zone string, req *apiv1.CreateHostReques
 		for _, c := range req.HostInstance.GCP.AcceleratorConfigs {
 			configs = append(configs, &compute.AcceleratorConfig{
 				AcceleratorCount: c.AcceleratorCount,
-				AcceleratorType:  c.AcceleratorType,
+				AcceleratorType:  fmt.Sprintf("zones/%s/acceleratorTypes/%s", zone, c.AcceleratorType),
 			})
 		}
 		payload.GuestAccelerators = configs


### PR DESCRIPTION
The compute instance insert API requires the accelerator type to be a full or partial URL of the accelerator type resource