### PR TITLE
DockerIM can select updating CF deb packages during host creation or not

### DIFF
--- a/pkg/app/instances/docker.go
+++ b/pkg/app/instances/docker.go
@@ -38,13 +38,15 @@ const DockerIMType IMType = "docker"
 
 type DockerIMConfig struct {
 	DockerImageName      string
+	UpdateDebPackages    bool
 	HostOrchestratorPort int
 }
 
 const (
-	dockerLabelCreatedBy      = "created_by"
-	dockerLabelKeyManagedBy   = "managed_by"
-	dockerLabelValueManagedBy = "cloud_orchestrator"
+	dockerLabelCreatedBy           = "created_by"
+	dockerLabelKeyManagedBy        = "managed_by"
+	dockerLabelValueManagedBy      = "cloud_orchestrator"
+	envNameAutoUpdateCFDebPackages = "AUTO_UPDATE_CF_DEBIAN_PACKAGES"
 )
 
 // Docker implementation of the instance manager.
@@ -87,6 +89,7 @@ func (m *DockerInstanceManager) CreateHost(zone string, _ *apiv1.CreateHostReque
 	config := &container.Config{
 		AttachStdin: true,
 		Image:       m.Config.Docker.DockerImageName,
+		Env:         []string{fmt.Sprintf("%s=%t", envNameAutoUpdateCFDebPackages, m.Config.Docker.UpdateDebPackages)},
 		Tty:         true,
 		Labels: map[string]string{
 			dockerLabelCreatedBy:    user.Username(),

--- a/scripts/on-premises/single-server/conf.toml
+++ b/scripts/on-premises/single-server/conf.toml
@@ -27,6 +27,7 @@ AllowSelfSignedHostSSLCertificate = true
 
 [InstanceManager.Docker]
 DockerImageName = "cuttlefish-orchestration:latest"
+UpdateDebPackages = false
 HostOrchestratorPort = 2080
 
 [[WebRTC.IceServers]]


### PR DESCRIPTION
Bug: b/408156615

Since we've observed updating CF debian packages at the entrypoint of docker instance can reach to the timeout of host creation, this change is for providing option that running docker image without performing `apt update` & `apt install`.