### PR TITLE
Define cvdr E2E test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ tags
 *.tfstate
 *.tfstate.*
 *.tfvars
+
+/bazel-*
+/**/bazel-*
+MODULE.bazel.lock

--- a/e2etests/MODULE.bazel
+++ b/e2etests/MODULE.bazel
@@ -1,0 +1,1 @@
+bazel_dep(name = "rules_shell", version = "0.4.0")

--- a/e2etests/cvdr/BUILD.bazel
+++ b/e2etests/cvdr/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@rules_shell//shell:sh_library.bzl", "sh_library")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
+sh_library(
+    name = "cvdr_common_utils",
+    srcs = ["common_utils.sh"],
+)
+
+sh_test(
+    name = "cvdr_host_create_test",
+    srcs = ["cvdr_host_create_test.sh"],
+    data = [":cvdr_common_utils"],
+)

--- a/e2etests/cvdr/README.md
+++ b/e2etests/cvdr/README.md
@@ -1,0 +1,19 @@
+# E2E test of cvdr
+
+## Prerequisite
+
+- Test runner should run Cloud Orchestrator on the machine where testing machine
+can access.
+- Test runner should prepare `cvdr` runnable in the testing machine.
+- Test runner should prepare the configuration file of `cvdr` including
+accessible URL of Cloud Orchestrator.
+
+## Test procedure
+
+```
+cd /path/to/cloud-android-orchestration
+cd e2etests
+bazel test //cvdr/... \
+  --test_env=CVDR_PATH=${CVDR_PATH} \
+  --test_env=CVDR_CONFIG_PATH=${CVDR_CONFIG_PATH}
+```

--- a/e2etests/cvdr/common_utils.sh
+++ b/e2etests/cvdr/common_utils.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+function validate_components() {
+    echo "Path of cvdr: ${CVDR_PATH}"
+    echo "Path of the configuration file for cvdr: ${CVDR_CONFIG_PATH}"
+    if [ ! -f "${CVDR_PATH}" ]; then
+        echo "Cannot find cvdr from ${CVDR_PATH}"
+        exit 1
+    fi
+    if [ ! -f "${CVDR_CONFIG_PATH}" ]; then
+        echo "Cannot find configuration file of cvdr from ${CVDR_CONFIG_PATH}"
+        exit 1
+    fi
+}
+
+function cvdr() {
+    HOME=${PWD} CVDR_USER_CONFIG_PATH=${CVDR_CONFIG_PATH} ${CVDR_PATH} $@
+}

--- a/e2etests/cvdr/cvdr_host_create_test.sh
+++ b/e2etests/cvdr/cvdr_host_create_test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e -x
+source ${TEST_SRCDIR}/_main/cvdr/common_utils.sh
+validate_components
+
+HOSTNAME=$(cvdr host create)
+cvdr host delete ${HOSTNAME}


### PR DESCRIPTION
Based on the design at go/cvdr-e2e-test-dd, this PR contains the rough impl of cvdr E2E test with the simplest test case(`cvdr host create`).

Presubmit check should be appended in the following PR. (https://github.com/google/cloud-android-orchestration/pull/441)