### PR TITLE
cvdr create uses new HO APIs for dealing with user artifact & image dir

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/PaesslerAG/jsonpath v0.1.1
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/docker/docker v27.3.1+incompatible
-	github.com/google/android-cuttlefish/frontend/src/host_orchestrator v0.0.0-20250716000344-c2f28e82c481
-	github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20250716000344-c2f28e82c481
+	github.com/google/android-cuttlefish/frontend/src/host_orchestrator v0.0.0-20250721193015-1143bc103bd7
+	github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20250721193015-1143bc103bd7
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.0
@@ -54,7 +54,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/android-cuttlefish/base/cvd/cuttlefish/host/commands/cvd/cli/parser/golang v0.0.0-20250707165013-373c65abbeb6 // indirect
-	github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20250716000344-c2f28e82c481 // indirect
+	github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20250721193015-1143bc103bd7 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/s2a-go v0.1.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -136,6 +136,8 @@ github.com/google/android-cuttlefish/frontend/src/host_orchestrator v0.0.0-20250
 github.com/google/android-cuttlefish/frontend/src/host_orchestrator v0.0.0-20250715175251-cf0d080a6c14/go.mod h1:A/uG8X6BuEAPiyBNrcecYyrQW3J0ClATXO3xc5HelJI=
 github.com/google/android-cuttlefish/frontend/src/host_orchestrator v0.0.0-20250716000344-c2f28e82c481 h1:EVzzG8benQnj0QylYF/VkGEinJg0lfJ1HxgBFE7nZQQ=
 github.com/google/android-cuttlefish/frontend/src/host_orchestrator v0.0.0-20250716000344-c2f28e82c481/go.mod h1:A/uG8X6BuEAPiyBNrcecYyrQW3J0ClATXO3xc5HelJI=
+github.com/google/android-cuttlefish/frontend/src/host_orchestrator v0.0.0-20250721193015-1143bc103bd7 h1:0jhmI/ZXl6+uWBPP4OdvKZH7WiF2dLOAoUOgXhtrFlQ=
+github.com/google/android-cuttlefish/frontend/src/host_orchestrator v0.0.0-20250721193015-1143bc103bd7/go.mod h1:A/uG8X6BuEAPiyBNrcecYyrQW3J0ClATXO3xc5HelJI=
 github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20241015220958-6d128c03da81 h1:CYRoqG++A4l2UKvLLzUDaWA+NzJY8zAt2j/FEVu3lDo=
 github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20241015220958-6d128c03da81/go.mod h1:KPb7LvjOt8oanRFqjgBjp6Hc/E60usOKGpeQlEWUDBk=
 github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20241028162827-6c01d79fd632 h1:BQjnXiwag9KrdLn2YMJvPtuj2/Ow2h//DGJlRT31aDE=
@@ -156,6 +158,8 @@ github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20250715001
 github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20250715001549-a984a48637bc/go.mod h1:6mij3FVAIDg96EUJgnogUePOBDCTDBJFu0y4Hf7IYeo=
 github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20250716000344-c2f28e82c481 h1:u+LmEendWFzXg66TTz+3MXmSYiJ4XZ0mPDGJZxZM/F0=
 github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20250716000344-c2f28e82c481/go.mod h1:iqcfOjxU+PFj47bb+MGbk/XkLe4HCvgRfZSLGE2uabo=
+github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20250721193015-1143bc103bd7 h1:zlF3o4Cvs5A/G0hed4BbHJro4GNDf/0mSg99W+qN8r0=
+github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20250721193015-1143bc103bd7/go.mod h1:iqcfOjxU+PFj47bb+MGbk/XkLe4HCvgRfZSLGE2uabo=
 github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20240822182916-7bea0dafdbde h1:laMjSvqBHvDZ9DB+YaM6I4y5t0a7zYQRorYLM1VJsyM=
 github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20240822182916-7bea0dafdbde/go.mod h1:iA3V13fYW7It3n+LqvgOkXAOhw56XAjS1vH43+kU/4o=
 github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20250408215131-62b596e12abb h1:y5LvPAJGP9N1umhGG1AO+x0nhY+ZjG7z49Umd7Kdn6w=
@@ -166,6 +170,8 @@ github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20250715001
 github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20250715001549-a984a48637bc/go.mod h1:7NIL7ZSSOXVn+8ykIfKPjCAV1apnAnXdR2ee6NJaEXc=
 github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20250716000344-c2f28e82c481 h1:yfxnNJYRTmksOLclWTW66KCKnRNc6xgBNgnzvmvy00c=
 github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20250716000344-c2f28e82c481/go.mod h1:yeMI/gOZJKXhAucXnv33lOvvt80WsrWbCDizYAllv/g=
+github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20250721193015-1143bc103bd7 h1:ZxQ8Ulb5+/BFYnGfiPtJD/iy8ZVIm+kYlB4aRq6zgkM=
+github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20250721193015-1143bc103bd7/go.mod h1:yeMI/gOZJKXhAucXnv33lOvvt80WsrWbCDizYAllv/g=
 github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
 github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=

--- a/pkg/cli/testing.go
+++ b/pkg/cli/testing.go
@@ -68,7 +68,7 @@ func (fakeHostService) CreateCVD(req *hoapi.CreateCVDRequest, creds hoclient.Bui
 }
 
 func (fakeHostService) CreateCVDOp(req *hoapi.CreateCVDRequest, creds hoclient.BuildAPICreds) (*hoapi.Operation, error) {
-	return nil, nil
+	return &hoapi.Operation{}, nil
 }
 
 func (fakeHostService) DeleteCVD(id string) error {
@@ -84,7 +84,7 @@ func (fakeHostService) UploadArtifact(filename string) error {
 }
 
 func (fakeHostService) ExtractArtifact(filename string) (*hoapi.Operation, error) {
-	return nil, nil
+	return &hoapi.Operation{}, nil
 }
 
 func (fakeHostService) CreateUploadDir() (string, error) {
@@ -99,14 +99,16 @@ func (fakeHostService) UploadFileWithOptions(uploadDir string, name string, opti
 	return nil
 }
 
-func (fakeHostService) ExtractFile(string, string) (*hoapi.Operation, error) { return nil, nil }
+func (fakeHostService) ExtractFile(string, string) (*hoapi.Operation, error) {
+	return &hoapi.Operation{}, nil
+}
 
 func (fakeHostService) CreateImageDirectory() (*hoapi.Operation, error) {
-	return nil, nil
+	return &hoapi.Operation{}, nil
 }
 
 func (fakeHostService) UpdateImageDirectoryWithUserArtifact(id, filename string) (*hoapi.Operation, error) {
-	return nil, nil
+	return &hoapi.Operation{}, nil
 }
 
 func (fakeHostService) DownloadRuntimeArtifacts(dst io.Writer) error {


### PR DESCRIPTION
This PR requires to have patches from Host Orchestrator suggested at https://github.com/google/android-cuttlefish/pull/1402, but I request the review on this PR in advance for the visibility to review corresponding HO changes. Details about canonical config is explained at there as well.

This PR also suggests to integrate `createCVDFromLocalBuild` or `createCVDFromLocalSrcs` into `createWithCanonicalConfig`, since those are already builds canonical config to pass it when creating CF instances.