### PR TITLE
Bump up modules from github.com/google/android-cuttlefish

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/PaesslerAG/jsonpath v0.1.1
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/docker/docker v27.3.1+incompatible
-	github.com/google/android-cuttlefish/frontend/src/host_orchestrator v0.0.0-20250715001549-a984a48637bc
-	github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20250715001549-a984a48637bc
+	github.com/google/android-cuttlefish/frontend/src/host_orchestrator v0.0.0-20250716000344-c2f28e82c481
+	github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20250716000344-c2f28e82c481
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.0
@@ -54,7 +54,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/android-cuttlefish/base/cvd/cuttlefish/host/commands/cvd/cli/parser/golang v0.0.0-20250707165013-373c65abbeb6 // indirect
-	github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20250715001549-a984a48637bc // indirect
+	github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20250716000344-c2f28e82c481 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/s2a-go v0.1.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect
@@ -93,7 +93,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.32.0 // indirect
 	go.opentelemetry.io/otel/trace v1.32.0 // indirect
 	golang.org/x/crypto v0.21.0 // indirect
-	golang.org/x/sys v0.18.0 // indirect
+	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -132,6 +132,10 @@ github.com/google/android-cuttlefish/frontend/src/host_orchestrator v0.0.0-20250
 github.com/google/android-cuttlefish/frontend/src/host_orchestrator v0.0.0-20250627234742-012697ff9b7a/go.mod h1:8PUZBZ3o0rrnvQsGXcfpBbT2mbqtL2pi7fPMzHFTIfg=
 github.com/google/android-cuttlefish/frontend/src/host_orchestrator v0.0.0-20250715001549-a984a48637bc h1:3HvYsl6vvk4UeGiIaQjRu+EHv8xrfNrJqs2gWtokBhs=
 github.com/google/android-cuttlefish/frontend/src/host_orchestrator v0.0.0-20250715001549-a984a48637bc/go.mod h1:8PUZBZ3o0rrnvQsGXcfpBbT2mbqtL2pi7fPMzHFTIfg=
+github.com/google/android-cuttlefish/frontend/src/host_orchestrator v0.0.0-20250715175251-cf0d080a6c14 h1:Y4yXIb0305k6J4Zxp+dtBYUr9sYpuVpohSIh4yZd8J8=
+github.com/google/android-cuttlefish/frontend/src/host_orchestrator v0.0.0-20250715175251-cf0d080a6c14/go.mod h1:A/uG8X6BuEAPiyBNrcecYyrQW3J0ClATXO3xc5HelJI=
+github.com/google/android-cuttlefish/frontend/src/host_orchestrator v0.0.0-20250716000344-c2f28e82c481 h1:EVzzG8benQnj0QylYF/VkGEinJg0lfJ1HxgBFE7nZQQ=
+github.com/google/android-cuttlefish/frontend/src/host_orchestrator v0.0.0-20250716000344-c2f28e82c481/go.mod h1:A/uG8X6BuEAPiyBNrcecYyrQW3J0ClATXO3xc5HelJI=
 github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20241015220958-6d128c03da81 h1:CYRoqG++A4l2UKvLLzUDaWA+NzJY8zAt2j/FEVu3lDo=
 github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20241015220958-6d128c03da81/go.mod h1:KPb7LvjOt8oanRFqjgBjp6Hc/E60usOKGpeQlEWUDBk=
 github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20241028162827-6c01d79fd632 h1:BQjnXiwag9KrdLn2YMJvPtuj2/Ow2h//DGJlRT31aDE=
@@ -150,6 +154,8 @@ github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20250627234
 github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20250627234742-012697ff9b7a/go.mod h1:6mij3FVAIDg96EUJgnogUePOBDCTDBJFu0y4Hf7IYeo=
 github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20250715001549-a984a48637bc h1:SiPk4adQpb0tD6tDpjPtWESmt+Gg5aksx5mExExKQXw=
 github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20250715001549-a984a48637bc/go.mod h1:6mij3FVAIDg96EUJgnogUePOBDCTDBJFu0y4Hf7IYeo=
+github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20250716000344-c2f28e82c481 h1:u+LmEendWFzXg66TTz+3MXmSYiJ4XZ0mPDGJZxZM/F0=
+github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20250716000344-c2f28e82c481/go.mod h1:iqcfOjxU+PFj47bb+MGbk/XkLe4HCvgRfZSLGE2uabo=
 github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20240822182916-7bea0dafdbde h1:laMjSvqBHvDZ9DB+YaM6I4y5t0a7zYQRorYLM1VJsyM=
 github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20240822182916-7bea0dafdbde/go.mod h1:iA3V13fYW7It3n+LqvgOkXAOhw56XAjS1vH43+kU/4o=
 github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20250408215131-62b596e12abb h1:y5LvPAJGP9N1umhGG1AO+x0nhY+ZjG7z49Umd7Kdn6w=
@@ -158,6 +164,8 @@ github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20250627234
 github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20250627234742-012697ff9b7a/go.mod h1:7NIL7ZSSOXVn+8ykIfKPjCAV1apnAnXdR2ee6NJaEXc=
 github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20250715001549-a984a48637bc h1:SBn4XluIYpzmf4OsERyDiBS9zvqvt6EE+DQOAaXnPNc=
 github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20250715001549-a984a48637bc/go.mod h1:7NIL7ZSSOXVn+8ykIfKPjCAV1apnAnXdR2ee6NJaEXc=
+github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20250716000344-c2f28e82c481 h1:yfxnNJYRTmksOLclWTW66KCKnRNc6xgBNgnzvmvy00c=
+github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20250716000344-c2f28e82c481/go.mod h1:yeMI/gOZJKXhAucXnv33lOvvt80WsrWbCDizYAllv/g=
 github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
 github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -458,6 +466,8 @@ golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.16.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
 golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
+golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/pkg/cli/testing.go
+++ b/pkg/cli/testing.go
@@ -105,6 +105,10 @@ func (fakeHostService) CreateImageDirectory() (*hoapi.Operation, error) {
 	return nil, nil
 }
 
+func (fakeHostService) UpdateImageDirectoryWithUserArtifact(id, filename string) (*hoapi.Operation, error) {
+	return nil, nil
+}
+
 func (fakeHostService) DownloadRuntimeArtifacts(dst io.Writer) error {
 	return nil
 }


### PR DESCRIPTION
As https://github.com/google/android-cuttlefish/pull/1397 is merged, add corresponding implementation on `fakeHostService` in advance.