### PR TITLE
Revert "Check that EnvConfig is convertible to proto."

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,6 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/google/android-cuttlefish/base/cvd/cuttlefish/host/commands/cvd/cli/parser/golang v0.0.0-20250707165013-373c65abbeb6 // indirect
 	github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20250721193015-1143bc103bd7 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/s2a-go v0.1.0 // indirect
@@ -99,7 +98,7 @@ require (
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
-	google.golang.org/protobuf v1.36.6 // indirect
+	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools/v3 v3.5.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -114,10 +114,6 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
-github.com/google/android-cuttlefish/base/cvd/cuttlefish/host/commands/cvd/cli/parser/golang v0.0.0-20250702161553-a4aa4ad95111 h1:0UPWZqmLTPYTQYJgFFK96yJczFR7bHL/C6UFjbkmCUs=
-github.com/google/android-cuttlefish/base/cvd/cuttlefish/host/commands/cvd/cli/parser/golang v0.0.0-20250702161553-a4aa4ad95111/go.mod h1:kwbXNWidCd9PO5n3Hjg1bhekqU5WST8/4A/n9OxrPiI=
-github.com/google/android-cuttlefish/base/cvd/cuttlefish/host/commands/cvd/cli/parser/golang v0.0.0-20250707165013-373c65abbeb6 h1:hn1I2Cc1vy9oucMsCulRtZH3pb6gIVpWD++Ka7u0dQQ=
-github.com/google/android-cuttlefish/base/cvd/cuttlefish/host/commands/cvd/cli/parser/golang v0.0.0-20250707165013-373c65abbeb6/go.mod h1:bvva0dAFlBcp6NJeehOBCmUsBWqN2SBLhGYxKNcamAI=
 github.com/google/android-cuttlefish/frontend/src/host_orchestrator v0.0.0-20240822210212-880a924dd887 h1:8FUb1el9+ZS0qetn5vBazvJzCEsqBjyXBJTWbEUreQ0=
 github.com/google/android-cuttlefish/frontend/src/host_orchestrator v0.0.0-20240822210212-880a924dd887/go.mod h1:jXT8KyxHnr3qWiE+qhZjhcrCquDFdl6h0LBpNoreP1U=
 github.com/google/android-cuttlefish/frontend/src/host_orchestrator v0.0.0-20240830204501-4bffeb28c143 h1:Nob+zxDE1tE5KKqBpwYIdMXwtgek8P7Tof14Z/JgccY=
@@ -552,8 +548,6 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
-google.golang.org/protobuf v1.36.6 h1:z1NpPI8ku2WgiWnf+t9wTPsn6eP1L7ksHUlkfLvd9xY=
-google.golang.org/protobuf v1.36.6/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/5YcXBHnY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=

--- a/pkg/cli/cvd.go
+++ b/pkg/cli/cvd.go
@@ -30,11 +30,9 @@ import (
 	"github.com/google/cloud-android-orchestration/pkg/cli/authz"
 	"github.com/google/cloud-android-orchestration/pkg/client"
 
-	lcpb "github.com/google/android-cuttlefish/base/cvd/cuttlefish/host/commands/cvd/cli/parser/golang"
 	hoapi "github.com/google/android-cuttlefish/frontend/src/host_orchestrator/api/v1"
 	hoclient "github.com/google/android-cuttlefish/frontend/src/libhoclient"
 	"github.com/hashicorp/go-multierror"
-	"google.golang.org/protobuf/encoding/protojson"
 )
 
 type RemoteCVDLocator struct {
@@ -211,12 +209,6 @@ func buildUAEnvConfig(artifacts []string, hostPkg string) (map[string]interface{
 	if err := uaEnvConfigTmpl.Execute(&b, uaEnvConfigTmplData{Artifacts: strings.Join(artifacts, ","), HostPkg: hostPkg}); err != nil {
 		return nil, fmt.Errorf("failed to fulfill template: %w", err)
 	}
-
-	es := lcpb.EnvironmentSpecification{}
-	if err := protojson.Unmarshal(b.Bytes(), &es); err != nil {
-		return nil, err
-	}
-
 	result := make(map[string]interface{})
 	if err := json.Unmarshal(b.Bytes(), &result); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal json: %w", err)
@@ -279,16 +271,6 @@ func (c *cvdCreator) createWithCanonicalConfig() ([]*hoapi.CVD, error) {
 	if err := c.uploadFilesAndUpdateEnvConfig(hostSrv, envConfig); err != nil {
 		return nil, fmt.Errorf("failed uploading files from environment config: %w", err)
 	}
-
-	es := lcpb.EnvironmentSpecification{}
-	b, err := json.Marshal(envConfig)
-	if err != nil {
-		return nil, fmt.Errorf("config is not convertible to JSON")
-	}
-	if err := protojson.Unmarshal(b, &es); err != nil {
-		return nil, fmt.Errorf("config is not convertible to load_config")
-	}
-
 	createReq := &hoapi.CreateCVDRequest{
 		EnvConfig: envConfig,
 	}

--- a/pkg/cli/cvd_test.go
+++ b/pkg/cli/cvd_test.go
@@ -15,9 +15,6 @@
 package cli
 
 import (
-	"encoding/json"
-	"fmt"
-	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -96,80 +93,5 @@ func TestGetHostOutRelativePathFailsUnknownTargetArch(t *testing.T) {
 
 	if err == nil {
 		t.Errorf("expected error")
-	}
-}
-
-func TestEnvConfigValidity(t *testing.T) {
-	cf, err := credentialsFactoryFromSource("none", "")
-	if err != nil {
-		t.Fatalf("couldn't make credentials factory")
-	}
-
-	f, err := os.CreateTemp(t.TempDir(), "test")
-	if err != nil {
-		t.Fatalf("couldn't create temp file")
-	}
-	fname := f.Name()
-	f.Close()
-
-	cc := cvdCreator{
-		client:             fakeClient{},
-		statePrinter:       newStatePrinter(io.Discard, false),
-		credentialsFactory: cf,
-		opts: CreateCVDOpts{
-			Host: "foo",
-		},
-	}
-
-	tests := []struct {
-		name      string
-		cfg       string
-		expectErr bool
-	}{
-		{
-			name:      "valid",
-			cfg:       `{"common": {"host_package": "%s"}, "instances": [{"vm": {"cpus": 8}}]}`,
-			expectErr: false,
-		},
-		{
-			name:      "invalid proto field",
-			cfg:       `{"common": {"host_package": "%s"}, "instances": [{"vm": {"cpus": "foobar"}}]}`,
-			expectErr: true,
-		},
-		{
-			name:      "additional fields",
-			cfg:       `{"common": {"host_package": "%s"}, "instances": [{"vm": {"cpus": "foobar", "xx": 42}}]}`,
-			expectErr: true,
-		},
-		{
-			name:      "completely different",
-			cfg:       `{"a": 1, "b": "%s"}`,
-			expectErr: true,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			cfg := fmt.Sprintf(test.cfg, fname)
-			ucfg := make(map[string]interface{})
-			if err := json.Unmarshal([]byte(cfg), &ucfg); err != nil {
-				t.Fatalf("config '%v' is not valid JSON: %s", cfg, err)
-			}
-
-			cc.opts.EnvConfig = ucfg
-			_, err := cc.createWithCanonicalConfig()
-			if err != nil && !test.expectErr {
-				t.Errorf("unexpected error: got: %s", err)
-			}
-			if err != nil && test.expectErr {
-				t.Logf("success: expected error, got: %s", err)
-			}
-			if err == nil && !test.expectErr {
-				t.Logf("success: expected success")
-			}
-			if err == nil && test.expectErr {
-				t.Errorf("unexpected success: config: %s", cfg)
-			}
-		})
 	}
 }


### PR DESCRIPTION
This reverts commit 91fae399a37f09478b0fc1f6c351e9da0ad6d52d.

One of the introduced dependencies requires go 1.22 which is not available on all platforms and is not required in the debian control file.

Bug=b/433332364