### PR TITLE
Re-land #437 "Check that EnvConfig is convertible to proto."

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	golang.org/x/term v0.18.0
 	google.golang.org/api v0.118.0
 	google.golang.org/grpc v1.56.3
+	google.golang.org/protobuf v1.32.0
 )
 
 require (
@@ -53,6 +54,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/google/android-cuttlefish/base/cvd/cuttlefish/host/commands/cvd/cli/parser/golang v0.0.0-20250725065612-ef53fac08041 // indirect
 	github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20250725065612-ef53fac08041 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/s2a-go v0.1.0 // indirect
@@ -98,7 +100,6 @@ require (
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
-	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools/v3 v3.5.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,10 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+github.com/google/android-cuttlefish/base/cvd/cuttlefish/host/commands/cvd/cli/parser/golang v0.0.0-20250724091406-393fc6ea415c h1:Cl/MP0VtJwYKeUi8mdkj3mHo1MEpmM2ZD/a/jWnz3/8=
+github.com/google/android-cuttlefish/base/cvd/cuttlefish/host/commands/cvd/cli/parser/golang v0.0.0-20250724091406-393fc6ea415c/go.mod h1:bvva0dAFlBcp6NJeehOBCmUsBWqN2SBLhGYxKNcamAI=
+github.com/google/android-cuttlefish/base/cvd/cuttlefish/host/commands/cvd/cli/parser/golang v0.0.0-20250725065612-ef53fac08041 h1:JIUDb0wDZZPy9CQ+NF6iYKAnbI093Z3SaJ4Rvt2O7Rw=
+github.com/google/android-cuttlefish/base/cvd/cuttlefish/host/commands/cvd/cli/parser/golang v0.0.0-20250725065612-ef53fac08041/go.mod h1:/fmo1ZtYaw+sIKK/ZW4BOlJmtQkHVKF7ea1nQXTZtOw=
 github.com/google/android-cuttlefish/frontend/src/host_orchestrator v0.0.0-20240822210212-880a924dd887 h1:8FUb1el9+ZS0qetn5vBazvJzCEsqBjyXBJTWbEUreQ0=
 github.com/google/android-cuttlefish/frontend/src/host_orchestrator v0.0.0-20240822210212-880a924dd887/go.mod h1:jXT8KyxHnr3qWiE+qhZjhcrCquDFdl6h0LBpNoreP1U=
 github.com/google/android-cuttlefish/frontend/src/host_orchestrator v0.0.0-20240830204501-4bffeb28c143 h1:Nob+zxDE1tE5KKqBpwYIdMXwtgek8P7Tof14Z/JgccY=
@@ -552,6 +556,8 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.32.0 h1:pPC6BG5ex8PDFnkbrGU3EixyhKcQ2aDuBS36lqK/C7I=
+google.golang.org/protobuf v1.32.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/cli/cvd.go
+++ b/pkg/cli/cvd.go
@@ -30,9 +30,11 @@ import (
 	"github.com/google/cloud-android-orchestration/pkg/cli/authz"
 	"github.com/google/cloud-android-orchestration/pkg/client"
 
+	lcpb "github.com/google/android-cuttlefish/base/cvd/cuttlefish/host/commands/cvd/cli/parser/golang"
 	hoapi "github.com/google/android-cuttlefish/frontend/src/host_orchestrator/api/v1"
 	hoclient "github.com/google/android-cuttlefish/frontend/src/libhoclient"
 	"github.com/hashicorp/go-multierror"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 type RemoteCVDLocator struct {
@@ -209,6 +211,12 @@ func buildUAEnvConfig(artifacts []string, hostPkg string) (map[string]interface{
 	if err := uaEnvConfigTmpl.Execute(&b, uaEnvConfigTmplData{Artifacts: strings.Join(artifacts, ","), HostPkg: hostPkg}); err != nil {
 		return nil, fmt.Errorf("failed to fulfill template: %w", err)
 	}
+
+	es := lcpb.EnvironmentSpecification{}
+	if err := protojson.Unmarshal(b.Bytes(), &es); err != nil {
+		return nil, err
+	}
+
 	result := make(map[string]interface{})
 	if err := json.Unmarshal(b.Bytes(), &result); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal json: %w", err)
@@ -271,6 +279,16 @@ func (c *cvdCreator) createWithCanonicalConfig() ([]*hoapi.CVD, error) {
 	if err := c.uploadFilesAndUpdateEnvConfig(hostSrv, envConfig); err != nil {
 		return nil, fmt.Errorf("failed uploading files from environment config: %w", err)
 	}
+
+	es := lcpb.EnvironmentSpecification{}
+	b, err := json.Marshal(envConfig)
+	if err != nil {
+		return nil, fmt.Errorf("config is not convertible to JSON")
+	}
+	if err := protojson.Unmarshal(b, &es); err != nil {
+		return nil, fmt.Errorf("config is not convertible to load_config")
+	}
+
 	createReq := &hoapi.CreateCVDRequest{
 		EnvConfig: envConfig,
 	}

--- a/pkg/cli/cvd_test.go
+++ b/pkg/cli/cvd_test.go
@@ -15,6 +15,9 @@
 package cli
 
 import (
+	"encoding/json"
+	"fmt"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -93,5 +96,80 @@ func TestGetHostOutRelativePathFailsUnknownTargetArch(t *testing.T) {
 
 	if err == nil {
 		t.Errorf("expected error")
+	}
+}
+
+func TestEnvConfigValidity(t *testing.T) {
+	cf, err := credentialsFactoryFromSource("none", "")
+	if err != nil {
+		t.Fatalf("couldn't make credentials factory")
+	}
+
+	f, err := os.CreateTemp(t.TempDir(), "test")
+	if err != nil {
+		t.Fatalf("couldn't create temp file")
+	}
+	fname := f.Name()
+	f.Close()
+
+	cc := cvdCreator{
+		client:             fakeClient{},
+		statePrinter:       newStatePrinter(io.Discard, false),
+		credentialsFactory: cf,
+		opts: CreateCVDOpts{
+			Host: "foo",
+		},
+	}
+
+	tests := []struct {
+		name      string
+		cfg       string
+		expectErr bool
+	}{
+		{
+			name:      "valid",
+			cfg:       `{"common": {"host_package": "%s"}, "instances": [{"vm": {"cpus": 8}}]}`,
+			expectErr: false,
+		},
+		{
+			name:      "invalid proto field",
+			cfg:       `{"common": {"host_package": "%s"}, "instances": [{"vm": {"cpus": "foobar"}}]}`,
+			expectErr: true,
+		},
+		{
+			name:      "additional fields",
+			cfg:       `{"common": {"host_package": "%s"}, "instances": [{"vm": {"cpus": "foobar", "xx": 42}}]}`,
+			expectErr: true,
+		},
+		{
+			name:      "completely different",
+			cfg:       `{"a": 1, "b": "%s"}`,
+			expectErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := fmt.Sprintf(test.cfg, fname)
+			ucfg := make(map[string]interface{})
+			if err := json.Unmarshal([]byte(cfg), &ucfg); err != nil {
+				t.Fatalf("config '%v' is not valid JSON: %s", cfg, err)
+			}
+
+			cc.opts.EnvConfig = ucfg
+			_, err := cc.createWithCanonicalConfig()
+			if err != nil && !test.expectErr {
+				t.Errorf("unexpected error: got: %s", err)
+			}
+			if err != nil && test.expectErr {
+				t.Logf("success: expected error, got: %s", err)
+			}
+			if err == nil && !test.expectErr {
+				t.Logf("success: expected success")
+			}
+			if err == nil && test.expectErr {
+				t.Errorf("unexpected success: config: %s", cfg)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Since the EnvConfig is converted to proto on the other end, check for errors by converting to proto on this end. Since we exported the proto in google/android-cuttlefish#1358, we can import it directly to use it.

(This commit re-lands #437 after revert in #443, ensuring it builds properly on a bookworm container running go 1.19.)