### PR TITLE
Bump up modules from google/android-cuttlefish

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/PaesslerAG/jsonpath v0.1.1
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/docker/docker v27.3.1+incompatible
-	github.com/google/android-cuttlefish/frontend/src/host_orchestrator v0.0.0-20250725065612-ef53fac08041
-	github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20250725065612-ef53fac08041
+	github.com/google/android-cuttlefish/frontend/src/host_orchestrator v0.0.0-20250731225726-21f888f64cef
+	github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20250731225726-21f888f64cef
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.0
@@ -55,7 +55,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/android-cuttlefish/base/cvd/cuttlefish/host/commands/cvd/cli/parser/golang v0.0.0-20250725065612-ef53fac08041 // indirect
-	github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20250725065612-ef53fac08041 // indirect
+	github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20250731225726-21f888f64cef // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/s2a-go v0.1.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,8 @@ github.com/google/android-cuttlefish/frontend/src/host_orchestrator v0.0.0-20250
 github.com/google/android-cuttlefish/frontend/src/host_orchestrator v0.0.0-20250721193015-1143bc103bd7/go.mod h1:A/uG8X6BuEAPiyBNrcecYyrQW3J0ClATXO3xc5HelJI=
 github.com/google/android-cuttlefish/frontend/src/host_orchestrator v0.0.0-20250725065612-ef53fac08041 h1:35+FtxSagco7iDkZMAq18X1Z4D+5eXlKDPXU1fyrrns=
 github.com/google/android-cuttlefish/frontend/src/host_orchestrator v0.0.0-20250725065612-ef53fac08041/go.mod h1:A/uG8X6BuEAPiyBNrcecYyrQW3J0ClATXO3xc5HelJI=
+github.com/google/android-cuttlefish/frontend/src/host_orchestrator v0.0.0-20250731225726-21f888f64cef h1:jst2JH3Ct6O4qfte/Q2JMQBz7BjkPORTnSZswcVDn5Y=
+github.com/google/android-cuttlefish/frontend/src/host_orchestrator v0.0.0-20250731225726-21f888f64cef/go.mod h1:A/uG8X6BuEAPiyBNrcecYyrQW3J0ClATXO3xc5HelJI=
 github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20241015220958-6d128c03da81 h1:CYRoqG++A4l2UKvLLzUDaWA+NzJY8zAt2j/FEVu3lDo=
 github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20241015220958-6d128c03da81/go.mod h1:KPb7LvjOt8oanRFqjgBjp6Hc/E60usOKGpeQlEWUDBk=
 github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20241028162827-6c01d79fd632 h1:BQjnXiwag9KrdLn2YMJvPtuj2/Ow2h//DGJlRT31aDE=
@@ -164,6 +166,8 @@ github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20250721193
 github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20250721193015-1143bc103bd7/go.mod h1:iqcfOjxU+PFj47bb+MGbk/XkLe4HCvgRfZSLGE2uabo=
 github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20250725065612-ef53fac08041 h1:B10+uj0TbHLwq4RFaQW39C6Xb4RZBY/SOtNJ0eQUH/0=
 github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20250725065612-ef53fac08041/go.mod h1:iqcfOjxU+PFj47bb+MGbk/XkLe4HCvgRfZSLGE2uabo=
+github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20250731225726-21f888f64cef h1:0AjfzSAaqGSDKJdy+38IgheVrgxa77nM9etmubhgLb8=
+github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20250731225726-21f888f64cef/go.mod h1:iqcfOjxU+PFj47bb+MGbk/XkLe4HCvgRfZSLGE2uabo=
 github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20240822182916-7bea0dafdbde h1:laMjSvqBHvDZ9DB+YaM6I4y5t0a7zYQRorYLM1VJsyM=
 github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20240822182916-7bea0dafdbde/go.mod h1:iA3V13fYW7It3n+LqvgOkXAOhw56XAjS1vH43+kU/4o=
 github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20250408215131-62b596e12abb h1:y5LvPAJGP9N1umhGG1AO+x0nhY+ZjG7z49Umd7Kdn6w=
@@ -178,6 +182,8 @@ github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20250721193
 github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20250721193015-1143bc103bd7/go.mod h1:yeMI/gOZJKXhAucXnv33lOvvt80WsrWbCDizYAllv/g=
 github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20250725065612-ef53fac08041 h1:r9k6elc6iAp9nEfunUOcIDDReN0h5vTBRXK8c2UdOm0=
 github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20250725065612-ef53fac08041/go.mod h1:yeMI/gOZJKXhAucXnv33lOvvt80WsrWbCDizYAllv/g=
+github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20250731225726-21f888f64cef h1:XbU1Jioh3iXttatMoHtyacah1W+dFbTajKAp60aouuk=
+github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20250731225726-21f888f64cef/go.mod h1:yeMI/gOZJKXhAucXnv33lOvvt80WsrWbCDizYAllv/g=
 github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
 github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=

--- a/pkg/cli/testing.go
+++ b/pkg/cli/testing.go
@@ -87,22 +87,6 @@ func (fakeHostService) ExtractArtifact(filename string) (*hoapi.Operation, error
 	return &hoapi.Operation{}, nil
 }
 
-func (fakeHostService) CreateUploadDir() (string, error) {
-	return "", nil
-}
-
-func (fakeHostService) UploadFile(uploadDir string, name string) error {
-	return nil
-}
-
-func (fakeHostService) UploadFileWithOptions(uploadDir string, name string, options hoclient.UploadOptions) error {
-	return nil
-}
-
-func (fakeHostService) ExtractFile(string, string) (*hoapi.Operation, error) {
-	return &hoapi.Operation{}, nil
-}
-
 func (fakeHostService) CreateImageDirectory() (*hoapi.Operation, error) {
 	return &hoapi.Operation{}, nil
 }


### PR DESCRIPTION
About removing all methods around legacy HO golang client APIs dealing with user artifacts.