### PR TITLE
Use hoclient.FakeHostOrchestrationClient for testing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,10 @@ require (
 	github.com/PaesslerAG/jsonpath v0.1.1
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/docker/docker v27.3.1+incompatible
+	github.com/google/android-cuttlefish/base/cvd/cuttlefish/host/commands/cvd/cli/parser/golang v0.0.0-20250725065612-ef53fac08041
 	github.com/google/android-cuttlefish/frontend/src/host_orchestrator v0.0.0-20250804003817-9fb5900ade64
-	github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20250804003817-9fb5900ade64
+	github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20250807215822-e80044f6bd34
+	github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20250807215822-e80044f6bd34
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.0
@@ -54,8 +56,6 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/google/android-cuttlefish/base/cvd/cuttlefish/host/commands/cvd/cli/parser/golang v0.0.0-20250725065612-ef53fac08041 // indirect
-	github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20250804003817-9fb5900ade64 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/s2a-go v0.1.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -172,6 +172,10 @@ github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20250731225
 github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20250731225726-21f888f64cef/go.mod h1:iqcfOjxU+PFj47bb+MGbk/XkLe4HCvgRfZSLGE2uabo=
 github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20250804003817-9fb5900ade64 h1:UeKkLr+9o1ZCC6cswo35U4ZfIB+AGdKA8Za56grC6uc=
 github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20250804003817-9fb5900ade64/go.mod h1:iqcfOjxU+PFj47bb+MGbk/XkLe4HCvgRfZSLGE2uabo=
+github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20250807002726-b07f88c86ba2 h1:P78x8jo+NwbFuZx0cgFmgMW2Be8LMr1naPA4AnjCF/Y=
+github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20250807002726-b07f88c86ba2/go.mod h1:iqcfOjxU+PFj47bb+MGbk/XkLe4HCvgRfZSLGE2uabo=
+github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20250807215822-e80044f6bd34 h1:y8ASoyKhk0KNw5PtJxaJHjALTcFTmv27wiXmkQ9bZKE=
+github.com/google/android-cuttlefish/frontend/src/libhoclient v0.0.0-20250807215822-e80044f6bd34/go.mod h1:iqcfOjxU+PFj47bb+MGbk/XkLe4HCvgRfZSLGE2uabo=
 github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20240822182916-7bea0dafdbde h1:laMjSvqBHvDZ9DB+YaM6I4y5t0a7zYQRorYLM1VJsyM=
 github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20240822182916-7bea0dafdbde/go.mod h1:iA3V13fYW7It3n+LqvgOkXAOhw56XAjS1vH43+kU/4o=
 github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20250408215131-62b596e12abb h1:y5LvPAJGP9N1umhGG1AO+x0nhY+ZjG7z49Umd7Kdn6w=
@@ -190,6 +194,8 @@ github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20250731225
 github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20250731225726-21f888f64cef/go.mod h1:yeMI/gOZJKXhAucXnv33lOvvt80WsrWbCDizYAllv/g=
 github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20250804003817-9fb5900ade64 h1:3WwRS9sf1DJR6QCF2GlHOThwfyaVK3mDL5JNTVOC8QE=
 github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20250804003817-9fb5900ade64/go.mod h1:yeMI/gOZJKXhAucXnv33lOvvt80WsrWbCDizYAllv/g=
+github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20250807215822-e80044f6bd34 h1:2YO3jxtnJZRDkGJ65MxUwJqDt9Jw1cbbxl5xCI0hS2g=
+github.com/google/android-cuttlefish/frontend/src/liboperator v0.0.0-20250807215822-e80044f6bd34/go.mod h1:yeMI/gOZJKXhAucXnv33lOvvt80WsrWbCDizYAllv/g=
 github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
 github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=

--- a/pkg/cli/testing.go
+++ b/pkg/cli/testing.go
@@ -1,15 +1,11 @@
 package cli
 
 import (
-	"io"
 	"net/url"
 
 	apiv1 "github.com/google/cloud-android-orchestration/api/v1"
 
-	hoapi "github.com/google/android-cuttlefish/frontend/src/host_orchestrator/api/v1"
 	hoclient "github.com/google/android-cuttlefish/frontend/src/libhoclient"
-	wclient "github.com/google/android-cuttlefish/frontend/src/libhoclient/webrtcclient"
-	"github.com/gorilla/websocket"
 )
 
 const unitTestServiceURL = "test://unit"
@@ -38,97 +34,9 @@ func (fakeClient) HostClient(host string) hoclient.HostOrchestratorClient {
 	if host == "" {
 		panic("empty host")
 	}
-	return &fakeHostService{}
+	return hoclient.NewFakeHostOrchestratorClient()
 }
 
 func (fakeClient) HostServiceURL(host string) (*url.URL, error) {
 	return nil, nil
-}
-
-type fakeHostService struct{}
-
-func (fakeHostService) GetInfraConfig() (*apiv1.InfraConfig, error) {
-	return nil, nil
-}
-
-func (fakeHostService) ConnectWebRTC(device string, observer wclient.Observer, logger io.Writer, opts hoclient.ConnectWebRTCOpts) (*wclient.Connection, error) {
-	return nil, nil
-}
-
-func (fakeHostService) ConnectADBWebSocket(device string) (*websocket.Conn, error) {
-	return nil, nil
-}
-
-func (fakeHostService) FetchArtifacts(req *hoapi.FetchArtifactsRequest, creds hoclient.BuildAPICreds) (*hoapi.FetchArtifactsResponse, error) {
-	return &hoapi.FetchArtifactsResponse{AndroidCIBundle: &hoapi.AndroidCIBundle{}}, nil
-}
-
-func (fakeHostService) CreateCVD(req *hoapi.CreateCVDRequest, creds hoclient.BuildAPICreds) (*hoapi.CreateCVDResponse, error) {
-	return &hoapi.CreateCVDResponse{CVDs: []*hoapi.CVD{{Name: "cvd-1"}}}, nil
-}
-
-func (fakeHostService) CreateCVDOp(req *hoapi.CreateCVDRequest, creds hoclient.BuildAPICreds) (*hoapi.Operation, error) {
-	return &hoapi.Operation{}, nil
-}
-
-func (fakeHostService) DeleteCVD(id string) error {
-	return nil
-}
-
-func (fakeHostService) ListCVDs() ([]*hoapi.CVD, error) {
-	return []*hoapi.CVD{{Name: "cvd-1"}}, nil
-}
-
-func (fakeHostService) UploadArtifact(filename string) error {
-	return nil
-}
-
-func (fakeHostService) ExtractArtifact(filename string) (*hoapi.Operation, error) {
-	return &hoapi.Operation{}, nil
-}
-
-func (fakeHostService) CreateImageDirectory() (*hoapi.Operation, error) {
-	return &hoapi.Operation{}, nil
-}
-
-func (fakeHostService) ListImageDirectories() (*hoapi.ListImageDirectoriesResponse, error) {
-	return &hoapi.ListImageDirectoriesResponse{}, nil
-}
-
-func (fakeHostService) UpdateImageDirectoryWithUserArtifact(id, filename string) (*hoapi.Operation, error) {
-	return &hoapi.Operation{}, nil
-}
-
-func (fakeHostService) DeleteImageDirectory(id string) (*hoapi.Operation, error) {
-	return &hoapi.Operation{}, nil
-}
-
-func (fakeHostService) DownloadRuntimeArtifacts(dst io.Writer) error {
-	return nil
-}
-
-func (fakeHostService) WaitForOperation(string, any) error { return nil }
-
-func (fakeHostService) CreateBugReport(string, hoclient.CreateBugReportOpts, io.Writer) error {
-	return nil
-}
-
-func (fakeHostService) Powerwash(groupName, instanceName string) error { return nil }
-
-func (fakeHostService) Stop(groupName, instanceName string) error { return nil }
-
-func (fakeHostService) Start(groupName, instanceName string, req *hoapi.StartCVDRequest) error {
-	return nil
-}
-
-func (fakeHostService) CreateSnapshot(groupName, instanceName string, req *hoapi.CreateSnapshotRequest) (*hoapi.CreateSnapshotResponse, error) {
-	return nil, nil
-}
-
-func (fakeHostService) Powerbtn(groupName, instanceName string) error {
-	return nil
-}
-
-func (fakeHostService) DeleteSnapshot(string) error {
-	return nil
 }


### PR DESCRIPTION
instead of the one from this project to avoid breakages when new methods are added to the interface.

Bug: b/436913689