### PR TITLE
Return error on ADB connection failure

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -1299,6 +1299,7 @@ func runConnectionWebrtcAgentCommand(flags *ConnectFlags, c *command, args []str
 	// Ask ADB server to connect even if the connection to the device already exists.
 	if err := opts.ADBServerProxy.Connect(ret.Status.ADB.Port); err != nil {
 		c.PrintErrf("Failed to connect ADB to device %q: %v\n", device, err)
+		return err
 	}
 
 	if ret.Controller == nil {
@@ -1338,11 +1339,13 @@ func runConnectionWebSocketAgentCommand(flags *ConnectFlags, c *command, args []
 		c.PrintErrf("Failed to listen ADB socket: %v", err)
 		return err
 	}
+	defer l.Close()
 	device := args[0]
 	adbPort := l.Addr().(*net.TCPAddr).Port
 	err = opts.ADBServerProxy.Connect(adbPort)
 	if err != nil {
 		c.PrintErrf("Failed to connect ADB to device: %v\n", err)
+		return err
 	}
 
 	for {


### PR DESCRIPTION
Thanks for this great project.

While exploring codebase, I found some suspicious behaviors related to err handling and resource closing , therefore I opened PR.

---

#### First issue related to err handling @ runConnectionWebSocketAgentCommand & runConnectionWebrtcAgentCommand

I think code below do not exit when adb connect is failed.
Should we `return err` when adb connect failed? or is this intended ?

```go
	if err := opts.ADBServerProxy.Connect(ret.Status.ADB.Port); err != nil {
		c.PrintErrf("Failed to connect ADB to device %q: %v\n", device, err)
	}
```

#### Second issue related to resource closing @ runConnectionWebSocketAgentCommand

I think code below do not close the `net.Listen` resource. 
Should we add `defer l.Close()` ?

```go
	l, err := net.Listen("tcp", "127.0.0.1:0")
	if err != nil {
		c.PrintErrf("Failed to listen ADB socket: %v", err)
		return err
	}
```

Thank you for taking time for reading my small fix.