### PR TITLE
Don't use statePrinter inside goroutines

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -1860,7 +1860,6 @@ type statePrinter struct {
 
 	// If true, visual features like colors and animations won't be displayed.
 	visualsOn bool
-	mu        sync.Mutex
 }
 
 func newStatePrinter(out io.Writer, verbose bool) *statePrinter {
@@ -1902,8 +1901,6 @@ func (p *statePrinter) print(msg string, state statePrinterState) {
 	if !p.visualsOn || state.Done {
 		result += "\n"
 	}
-	p.mu.Lock()
-	defer p.mu.Unlock()
 	fmt.Fprint(p.Out, result)
 }
 


### PR DESCRIPTION
Because it's not thread safe. Removed the locking logic since it can't be used in multithreaded code anyways.