### PR TITLE
Modify debian/control in GH workflow to inject nightly version on deb.

### DIFF
--- a/.github/actions/build-cuttlefish-cvdremote-debian-package/action.yaml
+++ b/.github/actions/build-cuttlefish-cvdremote-debian-package/action.yaml
@@ -12,6 +12,21 @@ runs:
   - name: install debuild dependencies
     run: apt install -y config-package-dev debhelper-compat devscripts git golang
     shell: bash
+  - name: Setup nightly version
+    run: |
+      # TODO(b/440196950): Setup condition on this step when we build
+      # stable/unstable versions here too.
+
+      # Modify debian/changelog to build debian package with desired version
+      # format.
+      # Stable/Unstable version format : X.Y.Z
+      # Nightly version format         : X.Y.Z~gitYYYYMMDD.<Github SHA 8 digit>
+      DATE=$(date -u +'%Y%m%d')
+      SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-8)
+      SUFFIX="~git${DATE}.${SHORT_SHA}"
+      sed -i "1s/(\([0-9]\+.[0-9]\+.[0-9]\+\))/(\1${SUFFIX})/g" \
+        build/debian/cuttlefish_cvdremote/debian/changelog
+    shell: bash
   - name: Build package
     run: |
       pushd build/debian/cuttlefish_cvdremote


### PR DESCRIPTION
About versioning semantics, I referred https://wiki.debian.org/Versioning.