### PR TITLE
Fix typo around postsubmit GH workflow

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -136,3 +136,4 @@ jobs:
             --amend ${IMAGE}:${TAG}-amd64 \
             --amend ${IMAGE}:${TAG}-arm64
           docker manifest push ${IMAGE}:${MANIFEST_TAG}
+        done


### PR DESCRIPTION
Postsubmit procedure about deployment of docker image was broken. Sorry for that.