### PR TITLE
Cloud Orchestrator can give hint to docker instances, that it's created by Cloud Orchestrator.

### DIFF
--- a/pkg/app/instances/docker.go
+++ b/pkg/app/instances/docker.go
@@ -362,6 +362,7 @@ func (m *DockerInstanceManager) createDockerVolumeIfNeeded(ctx context.Context, 
 func (m *DockerInstanceManager) createDockerContainer(ctx context.Context, user accounts.User) (string, error) {
 	config := &container.Config{
 		AttachStdin: true,
+		Env:         []string{"HANDLED_BY_CLOUD_ORCHESTRATOR=true"},
 		Image:       m.Config.Docker.DockerImageName,
 		Tty:         true,
 		Labels:      dockerLabelsDict(user),


### PR DESCRIPTION
Context: b/383428636

This hint can be used by https://github.com/google/android-cuttlefish/pull/1721.