### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/actions/build-cuttlefish-cvdremote-debian-package/action.yaml
+++ b/.github/actions/build-cuttlefish-cvdremote-debian-package/action.yaml
@@ -6,7 +6,7 @@ runs:
   using: "composite"
   steps:
   - name: Install dependencies
-    uses: actions/setup-go@v3
+    uses: actions/setup-go@v6
     with:
       go-version: 1.23.4
   - name: setup apt

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -58,7 +58,7 @@ jobs:
       image: debian@sha256:9258a75a7e4323c9e5562b361effc84ee747920116d8adfc98a465a5cdc9150e # debian:bookworm-20250407 (amd64)
     steps:
     - name: Checkout repository
-      uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # aka v2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Build debian package cuttlefish-cvdremote
       uses: ./.github/actions/build-cuttlefish-cvdremote-debian-package
       with:
@@ -83,7 +83,7 @@ jobs:
       image: debian@sha256:00cd074b40c4d99ff0c24540bdde0533ca3791edcdac0de36d6b9fb3260d89e2 # debian:bookworm-20250407 (arm64/v8)
     steps:
     - name: Checkout repository
-      uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # aka v2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Build debian package cuttlefish-cvdremote
       uses: ./.github/actions/build-cuttlefish-cvdremote-debian-package
       with:
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository
-      uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # aka v2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Build docker image
       run: docker build -t cuttlefish-cloud-orchestrator .
     - name: Authentication on GCP project android-cuttlefish-artifacts
@@ -131,7 +131,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
     - name: Checkout repository
-      uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # aka v2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Build docker image
       run: docker build -t cuttlefish-cloud-orchestrator .
     - name: Authentication on GCP project android-cuttlefish-artifacts
@@ -156,7 +156,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository
-      uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # aka v2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Authentication on GCP project android-cuttlefish-artifacts
       uses: 'google-github-actions/auth@v2'
       with:
@@ -184,7 +184,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository
-      uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # aka v2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Authentication on GCP project android-cuttlefish-artifacts
       uses: 'google-github-actions/auth@v2'
       with:

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository
-      uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # aka v2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Install dependencies
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v6
       with:
         go-version: 1.23.4
     - run: go version
@@ -37,11 +37,11 @@ jobs:
       image: debian@sha256:9258a75a7e4323c9e5562b361effc84ee747920116d8adfc98a465a5cdc9150e # debian:bookworm-20250407 (amd64)
     steps:
     - name: Checkout repository
-      uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # aka v2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Build debian package cuttlefish-cvdremote
       uses: ./.github/actions/build-cuttlefish-cvdremote-debian-package
     - name: Upload debian package
-      uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # aka v4.0.0
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
       with:
         name: cuttlefish-cvdremote-amd64
         path: cuttlefish-cvdremote_*.deb
@@ -52,11 +52,11 @@ jobs:
       image: debian@sha256:00cd074b40c4d99ff0c24540bdde0533ca3791edcdac0de36d6b9fb3260d89e2 # debian:bookworm-20250407 (arm64/v8)
     steps:
     - name: Checkout repository
-      uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # aka v2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Build debian package cuttlefish-cvdremote
       uses: ./.github/actions/build-cuttlefish-cvdremote-debian-package
     - name: Upload debian package
-      uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # aka v4.0.0
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
       with:
         name: cuttlefish-cvdremote-arm64
         path: cuttlefish-cvdremote_*.deb
@@ -65,13 +65,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository
-      uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # aka v2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Build docker image
       run: docker build -t cuttlefish-cloud-orchestrator .
     - name: Save docker image
       run: docker save --output cuttlefish-cloud-orchestrator.tar cuttlefish-cloud-orchestrator
     - name: Publish docker image
-      uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # aka v4.0.0
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
       with:
         name: cuttlefish-cloud-orchestrator-amd64
         path: cuttlefish-cloud-orchestrator.tar
@@ -80,13 +80,13 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
     - name: Checkout repository
-      uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # aka v2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Build docker image
       run: docker build -t cuttlefish-cloud-orchestrator .
     - name: Save docker image
       run: docker save --output cuttlefish-cloud-orchestrator.tar cuttlefish-cloud-orchestrator
     - name: Publish docker image
-      uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # aka v4.0.0
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
       with:
         name: cuttlefish-cloud-orchestrator-arm64
         path: cuttlefish-cloud-orchestrator.tar
@@ -96,14 +96,14 @@ jobs:
     needs: [build-cuttlefish-cloud-orchestrator-amd64-docker-image, build-cuttlefish-cvdremote-amd64-debian-package]
     steps:
     - name: Checkout repository
-      uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # aka v2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Download cuttlefish-orchestration
       run: |
         IMAGE_TAG="us-docker.pkg.dev/android-cuttlefish-artifacts/cuttlefish-orchestration/cuttlefish-orchestration:nightly"
         docker pull ${IMAGE_TAG}
         echo "orchestration_image_tag=${IMAGE_TAG}" >> $GITHUB_ENV
     - name: Download cuttlefish-cloud-orchestrator
-      uses: actions/download-artifact@7a1cd3216ca9260cd8022db641d960b1db4d1be4 # aka v4.0.0
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
       with:
         name: cuttlefish-cloud-orchestrator-amd64
     - name: Load and run cuttlefish-cloud-orchestrator
@@ -118,7 +118,7 @@ jobs:
           -v /var/run/docker.sock:/var/run/docker.sock \
           -t cuttlefish-cloud-orchestrator
     - name: Download cuttlefish-cvdremote
-      uses: actions/download-artifact@7a1cd3216ca9260cd8022db641d960b1db4d1be4 # aka v4.0.0
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
       with:
         name: cuttlefish-cvdremote-amd64
     - name: Install cuttlefish-cvdremote


### PR DESCRIPTION
> [!WARNING]
> You may currently be seeing a warning like this in your workflow runs:
>
> ```
> Node.js 20 actions are deprecated. The following actions are running on Node.js 20
> and may not work as expected: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675, actions/setup-go@v3, actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392, actions/download-artifact@7a1cd3216ca9260cd8022db641d960b1db4d1be4.
> Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.
> Please check if updated versions of these actions are available that support Node.js 24.
> To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment
> variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you
> can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true.
> For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
> ```
>
> The exact actions listed will vary per workflow.

Upgrades GitHub Actions to versions that support Node 24, since Node 20 is reaching EOL in April 2026.

## Changes

| Action | Old Version(s) | New Version | Compare | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [`a81bbbf`](https://github.com/actions/checkout/commit/a81bbbf8298c0fa03ea29cdc473d45769f953675) | [`de0fac2`](https://github.com/actions/checkout/commit/de0fac2e4500dabe0009e67214ff5f5447ce83dd) | [Diff](https://github.com/actions/checkout/compare/a81bbbf8298c...de0fac2e4500) | deployment.yaml, presubmit.yaml |
| `actions/download-artifact` | [`7a1cd32`](https://github.com/actions/download-artifact/commit/7a1cd3216ca9260cd8022db641d960b1db4d1be4) | [`3e5f45b`](https://github.com/actions/download-artifact/commit/3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c) | [Diff](https://github.com/actions/download-artifact/compare/7a1cd3216ca9...3e5f45b2cfb9) | presubmit.yaml |
| `actions/setup-go` | [`v3`](https://github.com/actions/setup-go/releases/tag/v3) | [`v6`](https://github.com/actions/setup-go/releases/tag/v6) | [Diff](https://github.com/actions/setup-go/compare/v3...v6) | action.yaml, presubmit.yaml |
| `actions/upload-artifact` | [`c7d193f`](https://github.com/actions/upload-artifact/commit/c7d193f32edcb7bfad88892161225aeda64e9392) | [`bbbca2d`](https://github.com/actions/upload-artifact/commit/bbbca2ddaa5d8feaa63e36b76fdaad77386f024f) | [Diff](https://github.com/actions/upload-artifact/compare/c7d193f32edc...bbbca2ddaa5d) | presubmit.yaml |
## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will default to Node 24 starting June 2nd, 2026.

- Node 20 EOL: April 2026
- Node 24 becomes default: June 2nd, 2026

## Release Notes

<details>
<summary>Release notes for actions/checkout</summary>

### [v4](https://github.com/actions/checkout/releases/tag/v4)

Prepare release v4.3.0 (https://github.com/actions/checkout/pull/2237)

### [v6.0.2](https://github.com/actions/checkout/releases/tag/v6.0.2)

## What's Changed
* Add orchestration_id to git user-agent when ACTIONS_ORCHESTRATION_ID is set by @TingluoHuang in https://github.com/actions/checkout/pull/2355
* Fix tag handling: preserve annotations and explicit fetch-tags by @ericsciple in https://github.com/actions/checkout/pull/2356

**Full Changelog**: https://github.com/actions/checkout/compare/v6.0.1...v6.0.2

### [v6.0.1](https://github.com/actions/checkout/releases/tag/v6.0.1)

## What's Changed
* Update all references from v5 and v4 to v6 by @ericsciple in https://github.com/actions/checkout/pull/2314
* Add worktree support for persist-credentials includeIf by @ericsciple in https://github.com/actions/checkout/pull/2327
* Clarify v6 README by @ericsciple in https://github.com/actions/checkout/pull/2328


**Full Changelog**: https://github.com/actions/checkout/compare/v6...v6.0.1

### [v6.0.0](https://github.com/actions/checkout/releases/tag/v6.0.0)

## What's Changed
* Update README to include Node.js 24 support details and requirements by @salmanmkc in https://github.com/actions/checkout/pull/2248
* Persist creds to a separate file by @ericsciple in https://github.com/actions/checkout/pull/2286
* v6-beta by @ericsciple in https://github.com/actions/checkout/pull/2298
* update readme/changelog for v6 by @ericsciple in https://github.com/actions/checkout/pull/2311


**Full Changelog**: https://github.com/actions/checkout/compare/v5.0.

*...truncated*

### [v5.0.1](https://github.com/actions/checkout/releases/tag/v5.0.1)

## What's Changed
* Port v6 cleanup to v5 by @ericsciple in https://github.com/actions/checkout/pull/2301


**Full Changelog**: https://github.com/actions/checkout/compare/v5...v5.0.1

</details>

<details>
<summary>Release notes for actions/setup-go</summary>

### [v6.3.0](https://github.com/actions/setup-go/releases/tag/v6.3.0)

## What's Changed
* Update default Go module caching to use go.mod by @priyagupta108 in https://github.com/actions/setup-go/pull/705
* Fix golang download url to go.dev by @178inaba in https://github.com/actions/setup-go/pull/469


**Full Changelog**: https://github.com/actions/setup-go/compare/v6...v6.3.0

### [v6.2.0](https://github.com/actions/setup-go/releases/tag/v6.2.0)

## What's Changed

### Enhancements
* Example for restore-only cache in documentation  by @aparnajyothi-y in https://github.com/actions/setup-go/pull/696
* Update Node.js version in action.yml by @ccoVeille in https://github.com/actions/setup-go/pull/691
* Documentation update of actions/checkout by @deining in https://github.com/actions/setup-go/pull/683

### Dependency updates
* Upgrade js-yaml from 3.14.1 to 3.14.2 by @dependabot in https://github.com/actions/setup-go/pull/682
* Upgr

*...truncated*

### [v5.6.0](https://github.com/actions/setup-go/releases/tag/v5.6.0)

## What's Changed
* Fall back to downloading from go.dev/dl instead of storage.googleapis.com/golang by @aparnajyothi-y in https://github.com/actions/setup-go/pull/689


**Full Changelog**: https://github.com/actions/setup-go/compare/v5...v5.6.0

### [v4.3.0](https://github.com/actions/setup-go/releases/tag/v4.3.0)

## What's Changed
* Fallback to downloading from go.dev/dl instead of storage.googleapis.com/golang by @aparnajyothi-y in https://github.com/actions/setup-go/pull/690


**Full Changelog**: https://github.com/actions/setup-go/compare/v4...v4.3.0

### [v6.1.0](https://github.com/actions/setup-go/releases/tag/v6.1.0)

## What's Changed

### Enhancements
* Fall back to downloading from go.dev/dl instead of storage.googleapis.com/golang by @nicholasngai in https://github.com/actions/setup-go/pull/665
* Add support for .tool-versions file and update workflow by @priya-kinthali in https://github.com/actions/setup-go/pull/673
* Add comprehensive breaking changes documentation for v6 by @mahabaleshwars in https://github.com/actions/setup-go/pull/674

### Dependency updates
* Upgrade eslint-config-prettier f

*...truncated*

</details>

<details>
<summary>Release notes for actions/upload-artifact</summary>

### [v7.0.0](https://github.com/actions/upload-artifact/releases/tag/v7.0.0)

## v7 What's new

### Direct Uploads

Adds support for uploading single files directly (unzipped). Callers can set the new `archive` parameter to `false` to skip zipping the file during upload. Right now, we only support single files. The action will fail if the glob passed resolves to multiple files. The `name` parameter is also ignored with this setting. Instead, the name of the artifact will be the name of the uploaded file.

### ESM

To support new versions of the `@actions/*` packag

*...truncated*

### [v6.0.0](https://github.com/actions/upload-artifact/releases/tag/v6.0.0)

## v6 - What's new

> [!IMPORTANT]
> actions/upload-artifact@v6 now runs on Node.js 24 (`runs.using: node24`) and requires a minimum Actions Runner version of 2.327.1. If you are using self-hosted runners, ensure they are updated before upgrading.
### Node.js 24

This release updates the runtime to Node.js 24. v5 had preliminary support for Node.js 24, however this action was by default still running on Node.js 20. Now this action by default will run on Node.js 24.

## What's Changed
* 

*...truncated*

### [v5.0.0](https://github.com/actions/upload-artifact/releases/tag/v5.0.0)

## What's Changed

**BREAKING CHANGE:** this update supports Node `v24.x`. This is not a breaking change per-se but we're treating it as such.

* Update README.md by @GhadimiR in https://github.com/actions/upload-artifact/pull/681
* Update README.md by @nebuk89 in https://github.com/actions/upload-artifact/pull/712
* Readme: spell out the first use of GHES by @danwkennedy in https://github.com/actions/upload-artifact/pull/727
* Update GHES guidance to include reference to Node 20 version 

*...truncated*

### [v4.6.2](https://github.com/actions/upload-artifact/releases/tag/v4.6.2)

## What's Changed
* Update to use artifact 2.3.2 package & prepare for new upload-artifact release by @salmanmkc in https://github.com/actions/upload-artifact/pull/685

## New Contributors
* @salmanmkc made their first contribution in https://github.com/actions/upload-artifact/pull/685

**Full Changelog**: https://github.com/actions/upload-artifact/compare/v4...v4.6.2

### [v4.6.1](https://github.com/actions/upload-artifact/releases/tag/v4.6.1)

## What's Changed
* Update to use artifact 2.2.2 package by @yacaovsnc in https://github.com/actions/upload-artifact/pull/673


**Full Changelog**: https://github.com/actions/upload-artifact/compare/v4...v4.6.1

</details>

<details>
<summary>Release notes for actions/download-artifact</summary>

### [v8.0.1](https://github.com/actions/download-artifact/releases/tag/v8.0.1)

## What's Changed

* Support for CJK characters in the artifact name by @danwkennedy in https://github.com/actions/download-artifact/pull/471
* Add a regression test for artifact name + content-type mismatches by @danwkennedy in https://github.com/actions/download-artifact/pull/472

**Full Changelog**: https://github.com/actions/download-artifact/compare/v8...v8.0.1

### [v8.0.0](https://github.com/actions/download-artifact/releases/tag/v8.0.0)

## v8 - What's new

> [!IMPORTANT]
> actions/download-artifact@v8 has been migrated to an ESM module. This should be transparent to the caller but forks might need to make significant changes.

> [!IMPORTANT]
> Hash mismatches will now error by default. Users can override this behavior with a setting change (see below).

### Direct downloads

To support direct uploads in `actions/upload-artifact`, the action will no longer attempt to unzip all downloaded files. Instead, the action chec

*...truncated*

### [v7.0.0](https://github.com/actions/download-artifact/releases/tag/v7.0.0)

## v7 - What's new

> [!IMPORTANT]
> actions/download-artifact@v7 now runs on Node.js 24 (`runs.using: node24`) and requires a minimum Actions Runner version of 2.327.1. If you are using self-hosted runners, ensure they are updated before upgrading.
### Node.js 24

This release updates the runtime to Node.js 24. v6 had preliminary support for Node 24, however this action was by default still running on Node.js 20. Now this action by default will run on Node.js 24.

## What's Changed
* U

*...truncated*

### [v6.0.0](https://github.com/actions/download-artifact/releases/tag/v6.0.0)

## What's Changed

**BREAKING CHANGE:** this update supports Node `v24.x`. This is not a breaking change per-se but we're treating it as such.

* Update README for download-artifact v5 changes by @yacaovsnc in https://github.com/actions/download-artifact/pull/417
* Update README with artifact extraction details by @yacaovsnc in https://github.com/actions/download-artifact/pull/424
* Readme: spell out the first use of GHES by @danwkennedy in https://github.com/actions/download-artifact/pull

*...truncated*

### [v5.0.0](https://github.com/actions/download-artifact/releases/tag/v5.0.0)

## What's Changed
* Update README.md by @nebuk89 in https://github.com/actions/download-artifact/pull/407
* BREAKING fix: inconsistent path behavior for single artifact downloads by ID by @GrantBirki in https://github.com/actions/download-artifact/pull/416

## v5.0.0

### 🚨 Breaking Change

This release fixes an inconsistency in path behavior for single artifact downloads by ID. **If you're downloading single artifacts by ID, the output path may change.**

#### What Changed

Previous

*...truncated*

</details>

## Notes

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA).

Worth running the workflows on a branch before merging to make sure everything still works.
