### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/actions/deploy-cuttlefish-cvdremote-debian-package/action.yaml
+++ b/.github/actions/deploy-cuttlefish-cvdremote-debian-package/action.yaml
@@ -8,7 +8,7 @@ runs:
   using: "composite"
   steps:
   - name: 'Set up Cloud SDK'
-    uses: 'google-github-actions/setup-gcloud@v3.0.0'
+    uses: 'google-github-actions/setup-gcloud@v3.0.1'
     with:
       version: '>= 363.0.0'
   - name: Deploy deb package into Artifact Registry

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -66,7 +66,7 @@ jobs:
     - name: Get exact filename
       run: echo "path=$(find . -name cuttlefish-cvdremote_*.deb)" >> $GITHUB_ENV
     - name: Authentication on GCP project android-cuttlefish-artifacts
-      uses: 'google-github-actions/auth@v2'
+      uses: 'google-github-actions/auth@v3'
       with:
         credentials_json: '${{ secrets.artifact-registry-uploader-json-creds }}'
     - name: Deploy debian package cuttlefish-cvdremote
@@ -91,7 +91,7 @@ jobs:
     - name: Get exact filename
       run: echo "path=$(find . -name cuttlefish-cvdremote_*.deb)" >> $GITHUB_ENV
     - name: Authentication on GCP project android-cuttlefish-artifacts
-      uses: 'google-github-actions/auth@v2'
+      uses: 'google-github-actions/auth@v3'
       with:
         credentials_json: '${{ secrets.artifact-registry-uploader-json-creds }}'
     - name: Deploy debian package cuttlefish-cvdremote
@@ -110,11 +110,11 @@ jobs:
     - name: Build docker image
       run: docker build -t cuttlefish-cloud-orchestrator .
     - name: Authentication on GCP project android-cuttlefish-artifacts
-      uses: 'google-github-actions/auth@v2'
+      uses: 'google-github-actions/auth@v3'
       with:
         credentials_json: '${{ secrets.artifact-registry-uploader-json-creds }}'
     - name: Login to Artifact Registry
-      uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # aka v3.5.0
+      uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
       with:
         registry: us-docker.pkg.dev
         username: _json_key
@@ -135,11 +135,11 @@ jobs:
     - name: Build docker image
       run: docker build -t cuttlefish-cloud-orchestrator .
     - name: Authentication on GCP project android-cuttlefish-artifacts
-      uses: 'google-github-actions/auth@v2'
+      uses: 'google-github-actions/auth@v3'
       with:
         credentials_json: '${{ secrets.artifact-registry-uploader-json-creds }}'
     - name: Login to Artifact Registry
-      uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # aka v3.5.0
+      uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
       with:
         registry: us-docker.pkg.dev
         username: _json_key
@@ -158,11 +158,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # aka v2
     - name: Authentication on GCP project android-cuttlefish-artifacts
-      uses: 'google-github-actions/auth@v2'
+      uses: 'google-github-actions/auth@v3'
       with:
         credentials_json: '${{ secrets.artifact-registry-uploader-json-creds }}'
     - name: Login to Artifact Registry
-      uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # aka v3.5.0
+      uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
       with:
         registry: us-docker.pkg.dev
         username: _json_key
@@ -186,11 +186,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # aka v2
     - name: Authentication on GCP project android-cuttlefish-artifacts
-      uses: 'google-github-actions/auth@v2'
+      uses: 'google-github-actions/auth@v3'
       with:
         credentials_json: '${{ secrets.artifact-registry-uploader-json-creds }}'
     - name: 'Set up Cloud SDK'
-      uses: 'google-github-actions/setup-gcloud@v3.0.0'
+      uses: 'google-github-actions/setup-gcloud@v3.0.1'
       with:
         version: '>= 363.0.0'
     - name: Deploy conf.toml

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -26,7 +26,7 @@ jobs:
     - name: Vet
       run: go vet ./...
     - name: Staticcheck
-      uses: dominikh/staticcheck-action@v1.3.1
+      uses: dominikh/staticcheck-action@v1.4.1
       with:
         version: "latest"
         install-go: false


### PR DESCRIPTION
Bumps GitHub Actions to their latest versions for bug fixes and security patches.

## Changes

| Action | Old Version(s) | New Version | Compare | Files |
|--------|---------------|-------------|---------|-------|
| `docker/login-action` | [`184bdaa`](https://github.com/docker/login-action/commit/184bdaa0721073962dff0199f1fb9940f07167d1) | [`b45d80f`](https://github.com/docker/login-action/commit/b45d80f862d83dbcd57f89517bcf500b2ab88fb2) | [Diff](https://github.com/docker/login-action/compare/184bdaa07210...b45d80f862d8) | deployment.yaml |
| `dominikh/staticcheck-action` | [`v1.3.1`](https://github.com/dominikh/staticcheck-action/releases/tag/v1.3.1) | [`v1.4.1`](https://github.com/dominikh/staticcheck-action/releases/tag/v1.4.1) | [Diff](https://github.com/dominikh/staticcheck-action/compare/v1.3.1...v1.4.1) | presubmit.yaml |
| `google-github-actions/auth` | [`v2`](https://github.com/google-github-actions/auth/releases/tag/v2) | [`v3`](https://github.com/google-github-actions/auth/releases/tag/v3) | [Diff](https://github.com/google-github-actions/auth/compare/v2...v3) | deployment.yaml |
| `google-github-actions/setup-gcloud` | [`v3.0.0`](https://github.com/google-github-actions/setup-gcloud/releases/tag/v3.0.0) | [`v3.0.1`](https://github.com/google-github-actions/setup-gcloud/releases/tag/v3.0.1) | [Diff](https://github.com/google-github-actions/setup-gcloud/compare/v3.0.0...v3.0.1) | action.yaml, deployment.yaml |

## Release Notes

<details>
<summary>Release notes for google-github-actions/auth</summary>

### [v3.0.0](https://github.com/google-github-actions/auth/releases/tag/v3.0.0)

## What's Changed
* Bump to Node 24 and remove old parameters by @sethvargo in https://github.com/google-github-actions/auth/pull/508
* Remove hacky script by @sethvargo in https://github.com/google-github-actions/auth/pull/509
* Release: v3.0.0 by @google-github-actions-bot in https://github.com/google-github-actions/auth/pull/510


**Full Changelog**: https://github.com/google-github-actions/auth/compare/v2...v3.0.0

### [v3](https://github.com/google-github-actions/auth/releases/tag/v3)

Floating v3 tag

### [v2.1.13](https://github.com/google-github-actions/auth/releases/tag/v2.1.13)

## What's Changed
* Update deps by @sethvargo in https://github.com/google-github-actions/auth/pull/506
* Release: v2.1.13 by @google-github-actions-bot in https://github.com/google-github-actions/auth/pull/507


**Full Changelog**: https://github.com/google-github-actions/auth/compare/v2.1.12...v2.1.13

### [v2.1.12](https://github.com/google-github-actions/auth/releases/tag/v2.1.12)

## What's Changed
* Add retries for getIDToken by @sethvargo in https://github.com/google-github-actions/auth/pull/502
* Release: v2.1.12 by @google-github-actions-bot in https://github.com/google-github-actions/auth/pull/503


**Full Changelog**: https://github.com/google-github-actions/auth/compare/v2.1.11...v2.1.12

### [v2.1.11](https://github.com/google-github-actions/auth/releases/tag/v2.1.11)

## What's Changed
* Update troubleshooting docs for Python by @sethvargo in https://github.com/google-github-actions/auth/pull/488
* Add linters by @sethvargo in https://github.com/google-github-actions/auth/pull/499
* Update deps by @sethvargo in https://github.com/google-github-actions/auth/pull/500
* Release: v2.1.11 by @google-github-actions-bot in https://github.com/google-github-actions/auth/pull/501


**Full Changelog**: https://github.com/google-github-actions/auth/compare/v2.1.10...v2.1

*...truncated*

</details>

<details>
<summary>Release notes for docker/login-action</summary>

### [v4.0.0](https://github.com/docker/login-action/releases/tag/v4.0.0)

* Node 24 as default runtime (requires [Actions Runner v2.327.1](https://github.com/actions/runner/releases/tag/v2.327.1) or later) by @crazy-max in https://github.com/docker/login-action/pull/929
* Switch to ESM and update config/test wiring by @crazy-max in https://github.com/docker/login-action/pull/927
* Bump @actions/core from 1.11.1 to 3.0.0 in https://github.com/docker/login-action/pull/919
* Bump @aws-sdk/client-ecr from 3.890.0 to 3.1000.0 in https://github.com/docker/login-action/pu

*...truncated*

### [v3.7.0](https://github.com/docker/login-action/releases/tag/v3.7.0)

* Add `scope` input to set scopes for the authentication token by @crazy-max in https://github.com/docker/login-action/pull/912
* Add support for AWS European Sovereign Cloud ECR by @dphi in https://github.com/docker/login-action/pull/914
* Ensure passwords are redacted with `registry-auth` input by @crazy-max in https://github.com/docker/login-action/pull/911
* build(deps): bump lodash from 4.17.21 to 4.17.23 in https://github.com/docker/login-action/pull/915

**Full Changelog**: https://g

*...truncated*

### [v3.6.0](https://github.com/docker/login-action/releases/tag/v3.6.0)

* Add `registry-auth` input for raw authentication to registries by @crazy-max in https://github.com/docker/login-action/pull/887
* Bump @aws-sdk/client-ecr to 3.890.0 in https://github.com/docker/login-action/pull/882 https://github.com/docker/login-action/pull/890
* Bump @aws-sdk/client-ecr-public to 3.890.0 in https://github.com/docker/login-action/pull/882 https://github.com/docker/login-action/pull/890
* Bump @docker/actions-toolkit from 0.62.1 to 0.63.0 in https://github.com/docker/logi

*...truncated*

</details>

<details>
<summary>Release notes for google-github-actions/setup-gcloud</summary>

### [v3.0.1](https://github.com/google-github-actions/setup-gcloud/releases/tag/v3.0.1)

## What's Changed
* Release: v3.0.1 by @google-github-actions-bot in https://github.com/google-github-actions/setup-gcloud/pull/729


**Full Changelog**: https://github.com/google-github-actions/setup-gcloud/compare/v3.0.0...v3.0.1

</details>

<details>
<summary>Release notes for dominikh/staticcheck-action</summary>

### [v1.4.1](https://github.com/dominikh/staticcheck-action/releases/tag/v1.4.1)

Version 1.4.1

### [v1.4.0](https://github.com/dominikh/staticcheck-action/releases/tag/v1.4.0)

Version 1.4.0

</details>

## Notes

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA).

Worth running the workflows on a branch before merging to make sure everything still works.
