### PR TITLE
Add description for `--host` flag of cvdr create

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -605,7 +605,7 @@ func createCommand(opts *subCommandOpts) *cobra.Command {
 			return runCreateCVDCommand(c, args, createFlags, opts)
 		},
 	}
-	create.Flags().StringVar(&createFlags.Host, hostFlag, "", "Specifies the host")
+	create.Flags().StringVar(&createFlags.Host, hostFlag, "", "Specifies the host. Creates a new host when it's not specified")
 	// Main build flags.
 	create.Flags().StringVar(&createFlags.MainBuild.Branch, branchFlag, "aosp-main", "The branch name")
 	create.Flags().StringVar(&createFlags.MainBuild.BuildID, buildIDFlag, "", "Android build identifier")


### PR DESCRIPTION
`--help` flag of `cvdr create` was ambiguous, to let users know what happens when it's not set. This PR amends flag explanation, to describe a new host is created when `--host` is not specified.

Context: b/501380691