### PR TITLE
ci: grant contents: read explicitly on presubmit and deploy entry workflows

### DIFF
--- a/.github/workflows/postsubmit.yaml
+++ b/.github/workflows/postsubmit.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     if: github.repository_owner == 'google'

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -6,6 +6,9 @@ on:
     branches-ignore:
       - main  # push events to main branch occur after PRs are merged, when the same checks were run
 
+permissions:
+  contents: read
+
 jobs:
   build-test:
     runs-on: ubuntu-24.04

--- a/.github/workflows/unstable-channel.yaml
+++ b/.github/workflows/unstable-channel.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - 'version-[0-9]+.[0-9]+-dev'
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     if: github.repository_owner == 'google'


### PR DESCRIPTION
Three workflow files declare no `permissions:` block. `deployment.yaml` (the reusable one called by `postsubmit` and `unstable-channel`) already has an explicit `permissions: contents: read`, but the three entry workflows still rely on the repo default.

- `presubmit.yaml` — build + test + format + vet + staticcheck + Debian/Docker artifact builds + E2E tests. All read-side from a GITHUB_TOKEN perspective.
- `postsubmit.yaml` and `unstable-channel.yaml` — both just delegate to `deployment.yaml` with secrets. Adding `contents: read` here intersects with the reusable`s declared `contents: read` = same scope, no regression. The `ARTIFACT_REGISTRY_UPLOADER` secret is what authenticates the actual GCP push.

YAML parses cleanly.